### PR TITLE
Feat(10): Mob Update

### DIFF
--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9cff2daf3fb4c564b93541ba10f3dbfc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Assassin.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Assassin.prefab
@@ -1,0 +1,821 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &109666166080168390
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9124379120054028841}
+  - component: {fileID: 6557623414258075959}
+  - component: {fileID: 2129112469058760600}
+  m_Layer: 5
+  m_Name: Enemy_Assassin_Damage_Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &9124379120054028841
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 109666166080168390}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1554356314878632775}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6557623414258075959
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 109666166080168390}
+  m_CullTransparentMesh: 1
+--- !u!114 &2129112469058760600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 109666166080168390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: -50
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &2061446013250074588
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1528951476645782602}
+  - component: {fileID: 3264205460480495472}
+  - component: {fileID: 5450221702700452681}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1528951476645782602
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2061446013250074588}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4496446459123089978}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3264205460480495472
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2061446013250074588}
+  m_CullTransparentMesh: 1
+--- !u!114 &5450221702700452681
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2061446013250074588}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4412568565249595983
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2279739571106489372}
+  - component: {fileID: 7884954598426230830}
+  - component: {fileID: 5834917659262062709}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2279739571106489372
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4412568565249595983}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4752236205504054511}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7884954598426230830
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4412568565249595983}
+  m_CullTransparentMesh: 1
+--- !u!114 &5834917659262062709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4412568565249595983}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4905749991991536292
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4752236205504054511}
+  - component: {fileID: 7271541313591943359}
+  m_Layer: 5
+  m_Name: Enemy_Assassin_HP_Slider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4752236205504054511
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4905749991991536292}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2279739571106489372}
+  - {fileID: 4496446459123089978}
+  m_Father: {fileID: 1554356314878632775}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7271541313591943359
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4905749991991536292}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 0, b: 0, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 1528951476645782602}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &5727764160240182489
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4496446459123089978}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4496446459123089978
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5727764160240182489}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1528951476645782602}
+  m_Father: {fileID: 4752236205504054511}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &7055654612612256485
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2527450488666439465}
+  - component: {fileID: 2361236983614565569}
+  - component: {fileID: 1081129033908463390}
+  - component: {fileID: 5791595770472838405}
+  - component: {fileID: 950626080030153357}
+  - component: {fileID: 4149701272461287800}
+  - component: {fileID: 4240035587536730883}
+  m_Layer: 0
+  m_Name: Enemy_Assassin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2527450488666439465
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7055654612612256485}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 56, y: 1, z: 59.48}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1554356314878632775}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2361236983614565569
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7055654612612256485}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1081129033908463390
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7055654612612256485}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8cd1de915f3277b4cbdcc69e60f4bd32, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &5791595770472838405
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7055654612612256485}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &950626080030153357
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7055654612612256485}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &4149701272461287800
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7055654612612256485}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6521822acc56ae7449a9d24e8fce65f3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyType: 1
+  elementType: 0
+  primaryDamageType: 0
+  enemyName: Enemy
+  hpSlider: {fileID: 7271541313591943359}
+  hpText: {fileID: 233782545555180790}
+  hpCanvas: {fileID: 1734484112750279896}
+  damageText: {fileID: 2129112469058760600}
+  deathEffect: {fileID: 0}
+  deathSound: {fileID: 0}
+  damageEffect: {fileID: 0}
+  attackDuration: 0.3
+--- !u!114 &4240035587536730883
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7055654612612256485}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e7f6caf48265f4c46bdbf06da9a6d865, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &7370212375240904935
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3601421560800581661}
+  - component: {fileID: 3825600771079902924}
+  - component: {fileID: 233782545555180790}
+  m_Layer: 5
+  m_Name: Enemy_Assassin_HP_Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3601421560800581661
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7370212375240904935}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1554356314878632775}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 150, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3825600771079902924
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7370212375240904935}
+  m_CullTransparentMesh: 1
+--- !u!114 &233782545555180790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7370212375240904935}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 150/150
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 8
+  m_fontSizeBase: 8
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &8801171351043667435
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1554356314878632775}
+  - component: {fileID: 1734484112750279896}
+  - component: {fileID: 7343561930151814795}
+  - component: {fileID: 7051556539309352592}
+  m_Layer: 5
+  m_Name: 'Enemy_Assassin_HP_Canvas '
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1554356314878632775
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8801171351043667435}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3601421560800581661}
+  - {fileID: 9124379120054028841}
+  - {fileID: 4752236205504054511}
+  m_Father: {fileID: 2527450488666439465}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 1}
+  m_SizeDelta: {x: 100, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &1734484112750279896
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8801171351043667435}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 10
+  m_TargetDisplay: 0
+--- !u!114 &7343561930151814795
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8801171351043667435}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!114 &7051556539309352592
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8801171351043667435}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Assassin.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Assassin.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bb9505b3f40307e4bac3ce9079d144dd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Final_Boss_Dark.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Final_Boss_Dark.prefab
@@ -1,0 +1,353 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6945971509939186544
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4745596562981903139}
+  - component: {fileID: 1123244402636294524}
+  - component: {fileID: 2532690669117123386}
+  - component: {fileID: 1226974173344998199}
+  - component: {fileID: 757430798151119069}
+  - component: {fileID: 7504770966501887046}
+  - component: {fileID: 461593559774776044}
+  m_Layer: 0
+  m_Name: Enemy_Final_Boss_Dark
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4745596562981903139
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6945971509939186544}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 52.139267, y: 1, z: 56.46194}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5991575550955671198}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1123244402636294524
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6945971509939186544}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2532690669117123386
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6945971509939186544}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &1226974173344998199
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6945971509939186544}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 1
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!114 &757430798151119069
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6945971509939186544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d98bee2fab6588a488101232e070e9b8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyType: 5
+  elementType: 1
+  primaryDamageType: 1
+  enemyName: Enemy
+  hpSlider: {fileID: 4280417401178142749}
+  hpText: {fileID: 0}
+  hpCanvas: {fileID: 433836680319969428}
+  damageText: {fileID: 0}
+  deathEffect: {fileID: 0}
+  deathSound: {fileID: 0}
+  damageEffect: {fileID: 0}
+  pullBulletPrefab: {fileID: 6546361683439244877, guid: f05aaaaa332ccd14e88351e76c18eaba, type: 3}
+  pullBulletSpeed: 10
+  pullBulletSpawnCount: 5
+  mapRadius: 20
+  pullBulletSpawnInterval: 3
+  pullBulletRange: 25
+  darkFloorHazardPrefab: {fileID: 4119778992378760006, guid: c3b13bb7acf8dd043be54d122769a78b, type: 3}
+  darkFloorDamage: 30
+  darkFloorCooldown: 5
+  bossBulletPrefab: {fileID: 5444615153167439068, guid: 6ca5e60b5516dcc41b9139b8196d4746, type: 3}
+  bossBulletDamage: 50
+  bossBulletCooldown: 3
+  bossBulletCount: 8
+  bossBulletRange: 15
+  bossBulletSpeed: 12
+  bulletPatterns: 000000000100000002000000030000000400000005000000
+  patternSwitchChance: 0.9
+  pullBulletChargeEffect: {fileID: 0}
+  darkFloorEffect: {fileID: 0}
+--- !u!114 &7504770966501887046
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6945971509939186544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ecd23123201d704ebe5fcc7dc1dcc61, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rotationSpeed: 2
+  stoppingDistance: 8
+  circleRadius: 12
+  allowMovement: 1
+  moveSpeedMultiplier: 0.5
+--- !u!54 &461593559774776044
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6945971509939186544}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!1001 &9138380967461260676
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 4745596562981903139}
+    m_Modifications:
+    - target: {fileID: 237462176129943191, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 237462176129943191, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 563530784247307188, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Final_Boss_HP_Slider
+      objectReference: {fileID: 0}
+    - target: {fileID: 1490054867214302677, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Final_Boss_HP_Panel
+      objectReference: {fileID: 0}
+    - target: {fileID: 1966717871863318255, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Final_Boss_Name_Text
+      objectReference: {fileID: 0}
+    - target: {fileID: 1981577893780808514, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Final_Boss_HP_Canvas  (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5628882578080405296, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Final_Boss_HP_Border
+      objectReference: {fileID: 0}
+    - target: {fileID: 8712436267875171931, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8712436267875171931, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8712436267875171931, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+--- !u!223 &433836680319969428 stripped
+Canvas:
+  m_CorrespondingSourceObject: {fileID: 8707500126718502160, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+  m_PrefabInstance: {fileID: 9138380967461260676}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4280417401178142749 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5022945011288225177, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+  m_PrefabInstance: {fileID: 9138380967461260676}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &5991575550955671198 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+  m_PrefabInstance: {fileID: 9138380967461260676}
+  m_PrefabAsset: {fileID: 0}

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Final_Boss_Dark.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Final_Boss_Dark.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d5f4cbe94249fe848ac1d46511e76ad7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Final_Boss_Light.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Final_Boss_Light.prefab
@@ -1,0 +1,343 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3899899079770035942
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6278620206084464612}
+  - component: {fileID: 1791746393020390850}
+  - component: {fileID: 3885238842362082114}
+  - component: {fileID: 2188004557342862281}
+  - component: {fileID: 828003735586343820}
+  - component: {fileID: 4625098660069673046}
+  - component: {fileID: 1928978250876284352}
+  m_Layer: 0
+  m_Name: Enemy_Final_Boss_Light
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6278620206084464612
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3899899079770035942}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 52.139267, y: 3, z: 56.46194}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5128298466070700206}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1791746393020390850
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3899899079770035942}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &3885238842362082114
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3899899079770035942}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &2188004557342862281
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3899899079770035942}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 1
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!114 &828003735586343820
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3899899079770035942}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 47938bf2ea80d8b42869c27712e02f15, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyType: 0
+  elementType: 0
+  primaryDamageType: 0
+  enemyName: Enemy
+  hpSlider: {fileID: 3416581209800332845}
+  hpText: {fileID: 0}
+  hpCanvas: {fileID: 1299418618042402468}
+  damageText: {fileID: 0}
+  deathEffect: {fileID: 0}
+  deathSound: {fileID: 0}
+  damageEffect: {fileID: 0}
+  railgunBeamPrefab: {fileID: 6505944401630606831, guid: 4a9fa4887c200864f97716aa133f382f, type: 3}
+  railgunDamage: 120
+  railgunChargeTime: 2
+  railgunCooldown: 4
+  swordBeamPrefab: {fileID: 4366707699226452152, guid: ecbc102024c96f9499bf8b8a5518cfdb, type: 3}
+  swordBeamDamage: 80
+  lightPillarPrefab: {fileID: 4443971174912647640, guid: 0b4501488271ee641ba5d60d85347d53, type: 3}
+  lightPillarDamage: 100
+  lightPillarInterval: 2
+--- !u!114 &4625098660069673046
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3899899079770035942}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ecd23123201d704ebe5fcc7dc1dcc61, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rotationSpeed: 2
+  stoppingDistance: 8
+  circleRadius: 12
+  allowMovement: 1
+  moveSpeedMultiplier: 0.5
+--- !u!54 &1928978250876284352
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3899899079770035942}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!1001 &7700934782549222324
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6278620206084464612}
+    m_Modifications:
+    - target: {fileID: 237462176129943191, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 237462176129943191, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 563530784247307188, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Final_Boss_HP_Slider
+      objectReference: {fileID: 0}
+    - target: {fileID: 1490054867214302677, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Final_Boss_HP_Panel
+      objectReference: {fileID: 0}
+    - target: {fileID: 1966717871863318255, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Final_Boss_Name_Text
+      objectReference: {fileID: 0}
+    - target: {fileID: 1981577893780808514, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Final_Boss_HP_Canvas  (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5628882578080405296, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Final_Boss_HP_Border
+      objectReference: {fileID: 0}
+    - target: {fileID: 8712436267875171931, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8712436267875171931, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8712436267875171931, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+--- !u!223 &1299418618042402468 stripped
+Canvas:
+  m_CorrespondingSourceObject: {fileID: 8707500126718502160, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+  m_PrefabInstance: {fileID: 7700934782549222324}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3416581209800332845 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5022945011288225177, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+  m_PrefabInstance: {fileID: 7700934782549222324}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &5128298466070700206 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+  m_PrefabInstance: {fileID: 7700934782549222324}
+  m_PrefabAsset: {fileID: 0}

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Final_Boss_Light.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Final_Boss_Light.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ca94be2d348e0e647b4fe543412446b6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Final_Boss_Neutral.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Final_Boss_Neutral.prefab
@@ -1,0 +1,346 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3432749387292509026
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5786310202332470888}
+  - component: {fileID: 8733997921397141762}
+  - component: {fileID: 992519371873546578}
+  - component: {fileID: 7167101046696226144}
+  - component: {fileID: 7587063483854613392}
+  - component: {fileID: 3863545674361301548}
+  - component: {fileID: 1831714238264432563}
+  m_Layer: 0
+  m_Name: Enemy_Final_Boss_Neutral
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5786310202332470888
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3432749387292509026}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 52.139267, y: 1, z: 56.46194}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1584231738517497304}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8733997921397141762
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3432749387292509026}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &992519371873546578
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3432749387292509026}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &7167101046696226144
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3432749387292509026}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 1
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!114 &7587063483854613392
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3432749387292509026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5bc6c6207e08a7b41bdc8c9712f22ebf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyType: 0
+  elementType: 0
+  primaryDamageType: 0
+  enemyName: Enemy
+  hpSlider: {fileID: 9060416261636445019}
+  hpText: {fileID: 0}
+  hpCanvas: {fileID: 4674530043833959378}
+  damageText: {fileID: 0}
+  deathEffect: {fileID: 0}
+  deathSound: {fileID: 0}
+  damageEffect: {fileID: 0}
+  lightOrbPrefab: {fileID: 6650104745104872665, guid: a0ceec0a13e4e594e94dc3bfe1a6021e, type: 3}
+  darkOrbPrefab: {fileID: 4231158396768756967, guid: 913db6cd50cbea84f81d3a5effac3358, type: 3}
+  orbSpawnPositions:
+  - {x: -8, y: 1.5, z: 0}
+  - {x: 8, y: 1.5, z: 0}
+  orbSpawnDelay: 1
+  spawnOrbsOnStart: 1
+  lightModeBoss: {fileID: 3147867682017286449, guid: ca94be2d348e0e647b4fe543412446b6, type: 3}
+  darkModeBoss: {fileID: 3233704907960519695, guid: d5f4cbe94249fe848ac1d46511e76ad7, type: 3}
+  orbHealthMultiplier: 1
+  orbSpeedMultiplier: 1
+  rotationSpeed: 10
+--- !u!114 &3863545674361301548
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3432749387292509026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ecd23123201d704ebe5fcc7dc1dcc61, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rotationSpeed: 2
+  stoppingDistance: 8
+  circleRadius: 12
+  allowMovement: 1
+  moveSpeedMultiplier: 0.5
+--- !u!54 &1831714238264432563
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3432749387292509026}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!1001 &4037483070237238978
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5786310202332470888}
+    m_Modifications:
+    - target: {fileID: 237462176129943191, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 237462176129943191, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 563530784247307188, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Final_Boss_HP_Slider
+      objectReference: {fileID: 0}
+    - target: {fileID: 1490054867214302677, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Final_Boss_HP_Panel
+      objectReference: {fileID: 0}
+    - target: {fileID: 1966717871863318255, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Final_Boss_Name_Text
+      objectReference: {fileID: 0}
+    - target: {fileID: 1981577893780808514, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Name
+      value: 'Enemy_Final_Boss_HP_Canvas '
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5628882578080405296, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Final_Boss_HP_Border
+      objectReference: {fileID: 0}
+    - target: {fileID: 8712436267875171931, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8712436267875171931, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8712436267875171931, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+--- !u!224 &1584231738517497304 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3311367466543268634, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+  m_PrefabInstance: {fileID: 4037483070237238978}
+  m_PrefabAsset: {fileID: 0}
+--- !u!223 &4674530043833959378 stripped
+Canvas:
+  m_CorrespondingSourceObject: {fileID: 8707500126718502160, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+  m_PrefabInstance: {fileID: 4037483070237238978}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &9060416261636445019 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5022945011288225177, guid: a5f1b1e60e93cf644b2b087df57b14eb, type: 3}
+  m_PrefabInstance: {fileID: 4037483070237238978}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Final_Boss_Neutral.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Final_Boss_Neutral.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d3024e592c03eef42b61fb35936d3558
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Middle_Boss.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Middle_Boss.prefab
@@ -1,0 +1,1192 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1373976152095490123
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1998664851065366277}
+  - component: {fileID: 2416112463138823640}
+  - component: {fileID: 1185100917109094725}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1998664851065366277
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1373976152095490123}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 313405900328466863}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2416112463138823640
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1373976152095490123}
+  m_CullTransparentMesh: 1
+--- !u!114 &1185100917109094725
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1373976152095490123}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2533616609966514127
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 648658167536080621}
+  - component: {fileID: 4814483507785219983}
+  - component: {fileID: 8102106410443982215}
+  - component: {fileID: 4550132008918843224}
+  m_Layer: 0
+  m_Name: Enemy_Middle_Boss_Grab_Firepoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &648658167536080621
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2533616609966514127}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0.7071068, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 1}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 888333890939422665}
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 180}
+--- !u!33 &4814483507785219983
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2533616609966514127}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8102106410443982215
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2533616609966514127}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &4550132008918843224
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2533616609966514127}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 0
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &3100891291212950824
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3381913423169099245}
+  - component: {fileID: 8563651803782996207}
+  - component: {fileID: 6443275490550045654}
+  - component: {fileID: 272381029588480149}
+  m_Layer: 5
+  m_Name: 'Enemy_Middle_Boss_HP_Canvas '
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3381913423169099245
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3100891291212950824}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4699184764409012878}
+  m_Father: {fileID: 888333890939422665}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &8563651803782996207
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3100891291212950824}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &6443275490550045654
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3100891291212950824}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!114 &272381029588480149
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3100891291212950824}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &3465413463388869529
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7960095718170217063}
+  - component: {fileID: 1677257552690930481}
+  - component: {fileID: 4709350377069274249}
+  m_Layer: 5
+  m_Name: Enemy_Middle_Boss_HP_Border
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7960095718170217063
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3465413463388869529}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4699184764409012878}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -30}
+  m_SizeDelta: {x: 710, y: 35}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1677257552690930481
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3465413463388869529}
+  m_CullTransparentMesh: 1
+--- !u!114 &4709350377069274249
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3465413463388869529}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.7513621, g: 0.7660377, b: 0.42637944, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4161104237638305822
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7011442323893839319}
+  - component: {fileID: 8546090959942675335}
+  - component: {fileID: 7017623201551757496}
+  - component: {fileID: 5236125660861168970}
+  m_Layer: 0
+  m_Name: Enemy_Middel_Boss_Bullet_FirePoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &7011442323893839319
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4161104237638305822}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.5, y: 0.5, z: 0.5, w: 0.5}
+  m_LocalPosition: {x: 1, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 888333890939422665}
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 90}
+--- !u!33 &8546090959942675335
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4161104237638305822}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7017623201551757496
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4161104237638305822}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &5236125660861168970
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4161104237638305822}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 0
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &4428764602468539194
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9192880317192115196}
+  - component: {fileID: 4944744239825923794}
+  - component: {fileID: 7878274589015165914}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9192880317192115196
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4428764602468539194}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1500286345636370710}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4944744239825923794
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4428764602468539194}
+  m_CullTransparentMesh: 1
+--- !u!114 &7878274589015165914
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4428764602468539194}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5536443810274939984
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7255784715403786435}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7255784715403786435
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5536443810274939984}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2349390229955858119}
+  m_Father: {fileID: 313405900328466863}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &6315152086195236849
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4613043552494569492}
+  - component: {fileID: 5753793515062738650}
+  - component: {fileID: 8517916525416991177}
+  m_Layer: 5
+  m_Name: Enemy_Middle_Boss_Name_Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4613043552494569492
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6315152086195236849}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4699184764409012878}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: 600, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5753793515062738650
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6315152086195236849}
+  m_CullTransparentMesh: 1
+--- !u!114 &8517916525416991177
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6315152086195236849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Middle_Boss
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28
+  m_fontSizeBase: 28
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &6733202330979447084
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 313405900328466863}
+  - component: {fileID: 3147306294660037614}
+  m_Layer: 5
+  m_Name: Enemy_Middle_Boss_HP_Slider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &313405900328466863
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6733202330979447084}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1998664851065366277}
+  - {fileID: 7255784715403786435}
+  - {fileID: 1500286345636370710}
+  m_Father: {fileID: 4699184764409012878}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -30}
+  m_SizeDelta: {x: 700, y: 25}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3147306294660037614
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6733202330979447084}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7878274589015165914}
+  m_FillRect: {fileID: 2349390229955858119}
+  m_HandleRect: {fileID: 9192880317192115196}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &6974686480641463183
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1500286345636370710}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1500286345636370710
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6974686480641463183}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9192880317192115196}
+  m_Father: {fileID: 313405900328466863}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &7447002808895435446
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2349390229955858119}
+  - component: {fileID: 4625424892588919836}
+  - component: {fileID: 2288718829226221679}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2349390229955858119
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7447002808895435446}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7255784715403786435}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4625424892588919836
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7447002808895435446}
+  m_CullTransparentMesh: 1
+--- !u!114 &2288718829226221679
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7447002808895435446}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7514799025897898486
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 888333890939422665}
+  - component: {fileID: 4351444390868246229}
+  - component: {fileID: 5379188386101017860}
+  - component: {fileID: 7119546332816685265}
+  - component: {fileID: 5663880915507199077}
+  - component: {fileID: 3243776448326217663}
+  - component: {fileID: 5398637161687571017}
+  m_Layer: 0
+  m_Name: Enemy_Middle_Boss
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &888333890939422665
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7514799025897898486}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 50.65506, y: 1.5, z: 56.301674}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7011442323893839319}
+  - {fileID: 648658167536080621}
+  - {fileID: 3381913423169099245}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4351444390868246229
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7514799025897898486}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5379188386101017860
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7514799025897898486}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &7119546332816685265
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7514799025897898486}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!114 &5663880915507199077
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7514799025897898486}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 935b6e3b031394e428e8bc7a5fa8485f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyType: 4
+  elementType: 0
+  primaryDamageType: 0
+  enemyName: Enemy
+  hpSlider: {fileID: 3147306294660037614}
+  hpText: {fileID: 0}
+  hpCanvas: {fileID: 8563651803782996207}
+  damageText: {fileID: 0}
+  deathEffect: {fileID: 0}
+  deathSound: {fileID: 0}
+  damageEffect: {fileID: 0}
+  grabRange: 0
+  grabDamage: 60
+  grabCooldown: 3
+  grabDuration: 1
+  pullForce: 8
+  grabProjectileSpeed: 15
+  grabFirePoint: {fileID: 648658167536080621}
+  bulletPrefab: {fileID: 4549591371034847080, guid: 4cffd1d870a7cb04d909d47c2c5af07b, type: 3}
+  firePoint: {fileID: 7011442323893839319}
+  bulletSpeed: 10
+  bulletCount: 20
+  bulletCooldown: 0.5
+  bulletRange: 100
+  floorHazardPrefab: {fileID: 6559232480380340793, guid: 9ef1a1d14d1b04f47a41998690746665, type: 3}
+  floorHazardDamage: 40
+  floorHazardDuration: 5
+  floorHazardCooldown: 8
+  floorHazardRadius: 3
+  maxFloorHazards: 20
+  floorHazardRange: 15
+  hazardsPerCast: 10
+  minDistanceFromPlayer: 2
+  minDistanceBetweenHazards: 4
+  grabProjectilePrefab: {fileID: 3977941196133518516, guid: 9dcf57a9cfbf5b441a7ec893498fec16, type: 3}
+--- !u!54 &3243776448326217663
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7514799025897898486}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &5398637161687571017
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7514799025897898486}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dce7d4f4ac687b647a55a13d281cc863, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rotationSpeed: 4
+  stoppingDistance: 2
+  circleRadius: 5
+--- !u!1 &8187814875138357814
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4699184764409012878}
+  - component: {fileID: 3378252428833402639}
+  - component: {fileID: 1813607733662198182}
+  m_Layer: 5
+  m_Name: Enemy_Middle_Boss_HP_Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4699184764409012878
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8187814875138357814}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4613043552494569492}
+  - {fileID: 7960095718170217063}
+  - {fileID: 313405900328466863}
+  m_Father: {fileID: 3381913423169099245}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -50}
+  m_SizeDelta: {x: 800, y: 120}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3378252428833402639
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8187814875138357814}
+  m_CullTransparentMesh: 1
+--- !u!114 &1813607733662198182
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8187814875138357814}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Middle_Boss.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Middle_Boss.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3ee240d8bc60606499409e679d06a718
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Middle_Boss2.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Middle_Boss2.prefab
@@ -1,0 +1,6375 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &72305526017050568
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3746484958283860149}
+  - component: {fileID: 4636343673499496644}
+  m_Layer: 5
+  m_Name: Enemy_MiddleBoss2_HP_Slider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3746484958283860149
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 72305526017050568}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2259137100219094278}
+  - {fileID: 3712349446237143289}
+  - {fileID: 8733892940906242984}
+  m_Father: {fileID: 4415466774123488138}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -30}
+  m_SizeDelta: {x: 700, y: 25}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4636343673499496644
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 72305526017050568}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 9053233769886214946}
+  m_FillRect: {fileID: 1800791505154882363}
+  m_HandleRect: {fileID: 5641702456871890812}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &287323618413998283
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2073403674511717517}
+  - component: {fileID: 8242097035594586682}
+  - component: {fileID: 8623372643091381022}
+  - component: {fileID: 696122000784666560}
+  m_Layer: 0
+  m_Name: Enemy_Middle_Boss2_Firepoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &2073403674511717517
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 287323618413998283}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.5, y: 0.5, z: 0.5, w: 0.5}
+  m_LocalPosition: {x: 1, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6394226457403268036}
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 90}
+--- !u!33 &8242097035594586682
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 287323618413998283}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8623372643091381022
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 287323618413998283}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &696122000784666560
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 287323618413998283}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 0
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &635776384789559188
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6260704091064922313}
+  - component: {fileID: 2474662896224406787}
+  - component: {fileID: 3532367319473657741}
+  m_Layer: 5
+  m_Name: Enemy_MiddleBoss2_HP_Border
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6260704091064922313
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 635776384789559188}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4415466774123488138}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -30}
+  m_SizeDelta: {x: 710, y: 35}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2474662896224406787
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 635776384789559188}
+  m_CullTransparentMesh: 1
+--- !u!114 &3532367319473657741
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 635776384789559188}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.7513621, g: 0.7660377, b: 0.42637944, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1503746900073412824
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7199576805749743591}
+  - component: {fileID: 5831537111638099046}
+  - component: {fileID: 192615770787192144}
+  - component: {fileID: 6736043803687895707}
+  m_Layer: 5
+  m_Name: 'Enemy_Middle_Boss2_HP_Canvas '
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7199576805749743591
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1503746900073412824}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4415466774123488138}
+  m_Father: {fileID: 6394226457403268036}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &5831537111638099046
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1503746900073412824}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &192615770787192144
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1503746900073412824}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!114 &6736043803687895707
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1503746900073412824}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &1634174768200366202
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6394226457403268036}
+  - component: {fileID: 5058161179763571871}
+  - component: {fileID: 1017934422751929549}
+  - component: {fileID: 1096258672902519433}
+  - component: {fileID: 6992160765534389963}
+  - component: {fileID: 2926909769710043269}
+  - component: {fileID: 3546671524709394823}
+  - component: {fileID: 3911866468226348983}
+  - component: {fileID: 6654080855166535317}
+  - component: {fileID: 1563111626601827760}
+  m_Layer: 0
+  m_Name: Enemy_Middle_Boss2
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6394226457403268036
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1634174768200366202}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 50, y: 1.5, z: 55}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2073403674511717517}
+  - {fileID: 7199576805749743591}
+  - {fileID: 7548527400194825708}
+  - {fileID: 3415508379410492397}
+  - {fileID: 4172963951597472977}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5058161179763571871
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1634174768200366202}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1017934422751929549
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1634174768200366202}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &1096258672902519433
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1634174768200366202}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!114 &6992160765534389963
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1634174768200366202}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eed45657338fc7c42bea9f7384b4800e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyType: 4
+  elementType: 0
+  primaryDamageType: 0
+  enemyName: Enemy
+  hpSlider: {fileID: 4636343673499496644}
+  hpText: {fileID: 0}
+  hpCanvas: {fileID: 5831537111638099046}
+  damageText: {fileID: 0}
+  deathEffect: {fileID: 0}
+  deathSound: {fileID: 0}
+  damageEffect: {fileID: 0}
+  railgunSystem: {fileID: 3911866468226348983}
+  railgunFirePoint: {fileID: 2073403674511717517}
+  railgunCooldown: 5
+  dashRange: 10
+  dashSpeed: 20
+  dashDistance: 12
+  dashCooldown: 3
+  dashWarningTime: 0.5
+  bulletPrefab: {fileID: 4977601195752174484, guid: 6f453bba8e922084283422e4dd08c4c4, type: 3}
+  firePoint: {fileID: 2073403674511717517}
+  bulletSpeed: 30
+  bulletCount: 10
+  bulletCooldown: 3
+  bulletRange: 100
+  dashWarningEffect: {fileID: 0}
+  dashTrailEffect: {fileID: 0}
+  monsterIgnoreRadius: 20
+  monsterTags:
+  - Enemy
+  - Boss
+  - MiddleBoss
+--- !u!54 &2926909769710043269
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1634174768200366202}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &3546671524709394823
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1634174768200366202}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8ab1788269ff634fb79fde06a40c73c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rotationSpeed: 4
+  stoppingDistance: 2
+--- !u!114 &3911866468226348983
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1634174768200366202}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84f08bbe1eb3986438a5b7689111793c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damage: 120
+  maxRange: 50
+  beamWidth: 0.5
+  chargingTime: 1
+  flashDuration: 0.5
+  canPenetrate: 1
+  enablePrediction: 1
+  predictionTime: 0.5
+  damageType: 1
+  elementType: 0
+  railgunBeam: {fileID: 1745102256056385137}
+  leftBeam: {fileID: 5230943333359376633}
+  rightBeam: {fileID: 1897546343295046148}
+  chargingParticle: {fileID: 6654080855166535317}
+  fireSound: {fileID: 0}
+--- !u!198 &6654080855166535317
+ParticleSystem:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1634174768200366202}
+  serializedVersion: 8
+  lengthInSec: 0.3
+  simulationSpeed: 1
+  stopAction: 0
+  cullingMode: 0
+  ringBufferMode: 0
+  ringBufferLoopRange: {x: 0, y: 1}
+  emitterVelocityMode: 1
+  looping: 1
+  prewarm: 0
+  playOnAwake: 1
+  useUnscaledTime: 0
+  autoRandomSeed: 1
+  startDelay:
+    serializedVersion: 2
+    minMaxState: 0
+    scalar: 0
+    minScalar: 0
+    maxCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    minCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+  moveWithTransform: 0
+  moveWithCustomTransform: {fileID: 0}
+  scalingMode: 1
+  randomSeed: 0
+  InitialModule:
+    serializedVersion: 3
+    enabled: 1
+    startLifetime:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0.2
+      minScalar: 5
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startSpeed:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 10
+      minScalar: 5
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startColor:
+      serializedVersion: 2
+      minMaxState: 0
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 1, g: 0.98700345, b: 0, a: 1}
+      maxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+      minGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+    startSize:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 2
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startSizeY:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startSizeZ:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startRotationX:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startRotationY:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startRotation:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    randomizeRotationDirection: 0
+    gravitySource: 0
+    maxNumParticles: 1000
+    customEmitterVelocity: {x: 0, y: 0, z: 0}
+    size3D: 0
+    rotation3D: 0
+    gravityModifier:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+  ShapeModule:
+    serializedVersion: 6
+    enabled: 1
+    type: 0
+    angle: 25
+    length: 5
+    boxThickness: {x: 0, y: 0, z: 0}
+    radiusThickness: 1
+    donutRadius: 0.2
+    m_Position: {x: 0, y: 0, z: 0}
+    m_Rotation: {x: 0, y: 0, z: 0}
+    m_Scale: {x: 1, y: 1, z: 1}
+    placementMode: 0
+    m_MeshMaterialIndex: 0
+    m_MeshNormalOffset: 0
+    m_MeshSpawn:
+      mode: 0
+      spread: 0
+      speed:
+        serializedVersion: 2
+        minMaxState: 0
+        scalar: 1
+        minScalar: 1
+        maxCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        minCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+    m_Mesh: {fileID: 0}
+    m_MeshRenderer: {fileID: 0}
+    m_SkinnedMeshRenderer: {fileID: 0}
+    m_Sprite: {fileID: 0}
+    m_SpriteRenderer: {fileID: 0}
+    m_UseMeshMaterialIndex: 0
+    m_UseMeshColors: 1
+    alignToDirection: 0
+    m_Texture: {fileID: 0}
+    m_TextureClipChannel: 3
+    m_TextureClipThreshold: 0
+    m_TextureUVChannel: 0
+    m_TextureColorAffectsParticles: 1
+    m_TextureAlphaAffectsParticles: 1
+    m_TextureBilinearFiltering: 0
+    randomDirectionAmount: 0
+    sphericalDirectionAmount: 0
+    randomPositionAmount: 0
+    radius:
+      value: 0.5
+      mode: 0
+      spread: 0
+      speed:
+        serializedVersion: 2
+        minMaxState: 0
+        scalar: 1
+        minScalar: 1
+        maxCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        minCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+    arc:
+      value: 360
+      mode: 0
+      spread: 0
+      speed:
+        serializedVersion: 2
+        minMaxState: 0
+        scalar: 1
+        minScalar: 1
+        maxCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        minCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0.33333334
+            outWeight: 0.33333334
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+  EmissionModule:
+    enabled: 1
+    serializedVersion: 4
+    rateOverTime:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 10
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    rateOverDistance:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    m_BurstCount: 1
+    m_Bursts:
+    - serializedVersion: 2
+      time: 0
+      countCurve:
+        serializedVersion: 2
+        minMaxState: 0
+        scalar: 50
+        minScalar: 30
+        maxCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        minCurve:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+      cycleCount: 1
+      repeatInterval: 0.01
+      probability: 1
+  SizeModule:
+    enabled: 0
+    curve:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 1
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 1
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    y:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 1
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 1
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    z:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 1
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 1
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    separateAxes: 0
+  RotationModule:
+    enabled: 0
+    x:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    y:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    curve:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0.7853982
+      minScalar: 0.7853982
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    separateAxes: 0
+  ColorModule:
+    enabled: 0
+    gradient:
+      serializedVersion: 2
+      minMaxState: 1
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      maxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+      minGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+  UVModule:
+    serializedVersion: 2
+    enabled: 0
+    mode: 0
+    timeMode: 0
+    fps: 30
+    frameOverTime:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 0.9999
+      minScalar: 0.9999
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 1
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 1
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    startFrame:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    speedRange: {x: 0, y: 1}
+    tilesX: 1
+    tilesY: 1
+    animationType: 0
+    rowIndex: 0
+    cycles: 1
+    uvChannelMask: -1
+    rowMode: 1
+    sprites:
+    - sprite: {fileID: 0}
+    flipU: 0
+    flipV: 0
+  VelocityModule:
+    enabled: 0
+    x:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    y:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    z:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    orbitalX:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    orbitalY:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    orbitalZ:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    orbitalOffsetX:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    orbitalOffsetY:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    orbitalOffsetZ:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    radial:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    speedModifier:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    inWorldSpace: 0
+  InheritVelocityModule:
+    enabled: 0
+    m_Mode: 0
+    m_Curve:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+  LifetimeByEmitterSpeedModule:
+    enabled: 0
+    m_Curve:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: -0.8
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0.2
+          inSlope: -0.8
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    m_Range: {x: 0, y: 1}
+  ForceModule:
+    enabled: 0
+    x:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    y:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    z:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    inWorldSpace: 0
+    randomizePerFrame: 0
+  ExternalForcesModule:
+    serializedVersion: 2
+    enabled: 0
+    multiplierCurve:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    influenceFilter: 0
+    influenceMask:
+      serializedVersion: 2
+      m_Bits: 4294967295
+    influenceList: []
+  ClampVelocityModule:
+    enabled: 0
+    x:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    y:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    z:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    magnitude:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    separateAxis: 0
+    inWorldSpace: 0
+    multiplyDragByParticleSize: 1
+    multiplyDragByParticleVelocity: 1
+    dampen: 0
+    drag:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+  NoiseModule:
+    enabled: 0
+    strength:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    strengthY:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    strengthZ:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    separateAxes: 0
+    frequency: 0.5
+    damping: 1
+    octaves: 1
+    octaveMultiplier: 0.5
+    octaveScale: 2
+    quality: 1
+    scrollSpeed:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    remap:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: -1
+          inSlope: 0
+          outSlope: 2
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 2
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    remapY:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: -1
+          inSlope: 0
+          outSlope: 2
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 2
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    remapZ:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: -1
+          inSlope: 0
+          outSlope: 2
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 2
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    remapEnabled: 0
+    positionAmount:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    rotationAmount:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    sizeAmount:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+  SizeBySpeedModule:
+    enabled: 0
+    curve:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 1
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 1
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    y:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 1
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 1
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    z:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 1
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 1
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    range: {x: 0, y: 1}
+    separateAxes: 0
+  RotationBySpeedModule:
+    enabled: 0
+    x:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    y:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    curve:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0.7853982
+      minScalar: 0.7853982
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    separateAxes: 0
+    range: {x: 0, y: 1}
+  ColorBySpeedModule:
+    enabled: 0
+    gradient:
+      serializedVersion: 2
+      minMaxState: 1
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      maxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+      minGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+    range: {x: 0, y: 1}
+  CollisionModule:
+    enabled: 0
+    serializedVersion: 4
+    type: 0
+    collisionMode: 0
+    colliderForce: 0
+    multiplyColliderForceByParticleSize: 0
+    multiplyColliderForceByParticleSpeed: 0
+    multiplyColliderForceByCollisionAngle: 1
+    m_Planes: []
+    m_Dampen:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    m_Bounce:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    m_EnergyLossOnCollision:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    minKillSpeed: 0
+    maxKillSpeed: 10000
+    radiusScale: 1
+    collidesWith:
+      serializedVersion: 2
+      m_Bits: 4294967295
+    maxCollisionShapes: 256
+    quality: 0
+    voxelSize: 0.5
+    collisionMessages: 0
+    collidesWithDynamic: 1
+    interiorCollisions: 0
+  TriggerModule:
+    enabled: 0
+    serializedVersion: 2
+    inside: 1
+    outside: 0
+    enter: 0
+    exit: 0
+    colliderQueryMode: 0
+    radiusScale: 1
+    primitives: []
+  SubModule:
+    serializedVersion: 2
+    enabled: 0
+    subEmitters:
+    - serializedVersion: 3
+      emitter: {fileID: 0}
+      type: 0
+      properties: 0
+      emitProbability: 1
+  LightsModule:
+    enabled: 0
+    ratio: 0
+    light: {fileID: 0}
+    randomDistribution: 1
+    color: 1
+    range: 1
+    intensity: 1
+    rangeCurve:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    intensityCurve:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    maxLights: 20
+  TrailModule:
+    enabled: 0
+    mode: 0
+    ratio: 1
+    lifetime:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    minVertexDistance: 0.2
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    ribbonCount: 1
+    shadowBias: 0.5
+    worldSpace: 0
+    dieWithParticles: 1
+    sizeAffectsWidth: 1
+    sizeAffectsLifetime: 0
+    inheritParticleColor: 1
+    generateLightingData: 0
+    splitSubEmitterRibbons: 0
+    attachRibbonsToTransform: 0
+    colorOverLifetime:
+      serializedVersion: 2
+      minMaxState: 0
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      maxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+      minGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+    widthOverTrail:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    colorOverTrail:
+      serializedVersion: 2
+      minMaxState: 0
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      maxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+      minGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+  CustomDataModule:
+    enabled: 0
+    mode0: 0
+    vectorComponentCount0: 4
+    color0:
+      serializedVersion: 2
+      minMaxState: 0
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      maxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+      minGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+    colorLabel0: Color
+    vector0_0:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel0_0: X
+    vector0_1:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel0_1: Y
+    vector0_2:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel0_2: Z
+    vector0_3:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel0_3: W
+    mode1: 0
+    vectorComponentCount1: 4
+    color1:
+      serializedVersion: 2
+      minMaxState: 0
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      maxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+      minGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: -1
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+    colorLabel1: Color
+    vector1_0:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel1_0: X
+    vector1_1:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel1_1: Y
+    vector1_2:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel1_2: Z
+    vector1_3:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    vectorLabel1_3: W
+--- !u!199 &1563111626601827760
+ParticleSystemRenderer:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1634174768200366202}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8cd1de915f3277b4cbdcc69e60f4bd32, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_RenderMode: 0
+  m_MeshDistribution: 0
+  m_SortMode: 0
+  m_MinParticleSize: 0
+  m_MaxParticleSize: 0.1
+  m_CameraVelocityScale: 0
+  m_VelocityScale: 0
+  m_LengthScale: 2
+  m_SortingFudge: 0
+  m_NormalDirection: 1
+  m_ShadowBias: 0
+  m_RenderAlignment: 0
+  m_Pivot: {x: 0, y: 0, z: 0}
+  m_Flip: {x: 0, y: 0, z: 0}
+  m_EnableGPUInstancing: 1
+  m_ApplyActiveColorSpace: 1
+  m_AllowRoll: 1
+  m_FreeformStretching: 0
+  m_RotateWithStretchDirection: 1
+  m_UseCustomVertexStreams: 0
+  m_VertexStreams: 00010304
+  m_UseCustomTrailVertexStreams: 0
+  m_TrailVertexStreams: 00010304
+  m_Mesh: {fileID: 0}
+  m_Mesh1: {fileID: 0}
+  m_Mesh2: {fileID: 0}
+  m_Mesh3: {fileID: 0}
+  m_MeshWeighting: 1
+  m_MeshWeighting1: 1
+  m_MeshWeighting2: 1
+  m_MeshWeighting3: 1
+  m_MaskInteraction: 0
+--- !u!1 &2034204175530303499
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3712349446237143289}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3712349446237143289
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2034204175530303499}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1800791505154882363}
+  m_Father: {fileID: 3746484958283860149}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2076751449186208520
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5641702456871890812}
+  - component: {fileID: 6503688656043090900}
+  - component: {fileID: 9053233769886214946}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5641702456871890812
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2076751449186208520}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8733892940906242984}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6503688656043090900
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2076751449186208520}
+  m_CullTransparentMesh: 1
+--- !u!114 &9053233769886214946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2076751449186208520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2109803861423334928
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7548527400194825708}
+  - component: {fileID: 1745102256056385137}
+  m_Layer: 0
+  m_Name: CenterBeam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7548527400194825708
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2109803861423334928}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6394226457403268036}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!120 &1745102256056385137
+LineRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2109803861423334928}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8cd1de915f3277b4cbdcc69e60f4bd32, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Positions:
+  - {x: 1, y: 1, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1.4551454
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 0.99045753, g: 1, b: 0, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: 0
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 1
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_MaskInteraction: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
+--- !u!1 &2197050938820686514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4415466774123488138}
+  - component: {fileID: 8706250696634495147}
+  - component: {fileID: 591309381292987840}
+  m_Layer: 5
+  m_Name: Enemy_Middle_Boss2_HP_Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4415466774123488138
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2197050938820686514}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3584398968471398716}
+  - {fileID: 6260704091064922313}
+  - {fileID: 3746484958283860149}
+  m_Father: {fileID: 7199576805749743591}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -50}
+  m_SizeDelta: {x: 800, y: 120}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8706250696634495147
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2197050938820686514}
+  m_CullTransparentMesh: 1
+--- !u!114 &591309381292987840
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2197050938820686514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3956557355023420845
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3584398968471398716}
+  - component: {fileID: 253991532906914316}
+  - component: {fileID: 6168814036604030568}
+  m_Layer: 5
+  m_Name: Enemy_MiddleBoss2_Name_Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3584398968471398716
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3956557355023420845}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4415466774123488138}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: 600, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &253991532906914316
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3956557355023420845}
+  m_CullTransparentMesh: 1
+--- !u!114 &6168814036604030568
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3956557355023420845}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Middle_Boss
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28
+  m_fontSizeBase: 28
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4786021943075447847
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1800791505154882363}
+  - component: {fileID: 2545429199047867279}
+  - component: {fileID: 4557035363762353851}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1800791505154882363
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4786021943075447847}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3712349446237143289}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2545429199047867279
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4786021943075447847}
+  m_CullTransparentMesh: 1
+--- !u!114 &4557035363762353851
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4786021943075447847}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6911149133581874740
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8733892940906242984}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8733892940906242984
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6911149133581874740}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5641702456871890812}
+  m_Father: {fileID: 3746484958283860149}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &7121118904360730465
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3415508379410492397}
+  - component: {fileID: 1897546343295046148}
+  m_Layer: 0
+  m_Name: RightBeam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3415508379410492397
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7121118904360730465}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6394226457403268036}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!120 &1897546343295046148
+LineRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7121118904360730465}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8cd1de915f3277b4cbdcc69e60f4bd32, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Positions:
+  - {x: 1, y: 1, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1.4551454
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 0.99045753, g: 1, b: 0, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: 0
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 1
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_MaskInteraction: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
+--- !u!1 &7285926712264572531
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4172963951597472977}
+  - component: {fileID: 5230943333359376633}
+  m_Layer: 0
+  m_Name: LeftBeam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4172963951597472977
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7285926712264572531}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6394226457403268036}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!120 &5230943333359376633
+LineRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7285926712264572531}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8cd1de915f3277b4cbdcc69e60f4bd32, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Positions:
+  - {x: 1, y: 1, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1.4551454
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 0.99045753, g: 1, b: 0, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: 0
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 1
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_MaskInteraction: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
+--- !u!1 &8191108182582560990
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2259137100219094278}
+  - component: {fileID: 3532141040146884233}
+  - component: {fileID: 1555069224791461801}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2259137100219094278
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8191108182582560990}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3746484958283860149}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3532141040146884233
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8191108182582560990}
+  m_CullTransparentMesh: 1
+--- !u!114 &1555069224791461801
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8191108182582560990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Middle_Boss2.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Middle_Boss2.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8b436578c653edb4cbce3ef85b4c6700
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Ranged.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Ranged.prefab
@@ -1,0 +1,917 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &270926953583311373
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2658241939901146667}
+  - component: {fileID: 5600802654301499134}
+  - component: {fileID: 4696063697310259261}
+  m_Layer: 0
+  m_Name: FirePoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2658241939901146667
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 270926953583311373}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 1}
+  m_LocalScale: {x: 0.1, y: 1, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5033047982814235756}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5600802654301499134
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 270926953583311373}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4696063697310259261
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 270926953583311373}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &662958207197817429
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1036397424283904794}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1036397424283904794
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 662958207197817429}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5809059473073145698}
+  m_Father: {fileID: 6715239122138385509}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &3420519449126765483
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4195508196215356347}
+  - component: {fileID: 3004808870799535737}
+  - component: {fileID: 52321937862142729}
+  m_Layer: 5
+  m_Name: Enemy_Ranged_HP_Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4195508196215356347
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3420519449126765483}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1516672101405468497}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 150, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3004808870799535737
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3420519449126765483}
+  m_CullTransparentMesh: 1
+--- !u!114 &52321937862142729
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3420519449126765483}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 150/150
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 8
+  m_fontSizeBase: 8
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &3719326664511029143
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6741904954373741005}
+  - component: {fileID: 2645899894289588520}
+  - component: {fileID: 3739303329076900304}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6741904954373741005
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3719326664511029143}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6715239122138385509}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2645899894289588520
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3719326664511029143}
+  m_CullTransparentMesh: 1
+--- !u!114 &3739303329076900304
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3719326664511029143}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5221109513776706849
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7057386594305983331}
+  - component: {fileID: 2627988983849184285}
+  - component: {fileID: 8688029935883353112}
+  m_Layer: 5
+  m_Name: Enemy_Ranged_Damage_Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &7057386594305983331
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5221109513776706849}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1516672101405468497}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2627988983849184285
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5221109513776706849}
+  m_CullTransparentMesh: 1
+--- !u!114 &8688029935883353112
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5221109513776706849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: -50
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &6164431519903445727
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1516672101405468497}
+  - component: {fileID: 2562708966553098909}
+  - component: {fileID: 6451933984443585929}
+  - component: {fileID: 5665981129108799338}
+  m_Layer: 5
+  m_Name: Enemy_Ranged_HP_Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1516672101405468497
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6164431519903445727}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4195508196215356347}
+  - {fileID: 7057386594305983331}
+  - {fileID: 6715239122138385509}
+  m_Father: {fileID: 5033047982814235756}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 2}
+  m_SizeDelta: {x: 100, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &2562708966553098909
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6164431519903445727}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 10
+  m_TargetDisplay: 0
+--- !u!114 &6451933984443585929
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6164431519903445727}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!114 &5665981129108799338
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6164431519903445727}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &7613049096078813820
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6715239122138385509}
+  - component: {fileID: 5114757515185780597}
+  m_Layer: 5
+  m_Name: Enemy_Ranged_HP_Slider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6715239122138385509
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7613049096078813820}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6741904954373741005}
+  - {fileID: 1036397424283904794}
+  m_Father: {fileID: 1516672101405468497}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5114757515185780597
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7613049096078813820}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 0, b: 0, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 5809059473073145698}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &8346770374851953987
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5809059473073145698}
+  - component: {fileID: 9067138750010496067}
+  - component: {fileID: 8956124253058665714}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5809059473073145698
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8346770374851953987}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1036397424283904794}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9067138750010496067
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8346770374851953987}
+  m_CullTransparentMesh: 1
+--- !u!114 &8956124253058665714
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8346770374851953987}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8413762502131051733
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5033047982814235756}
+  - component: {fileID: 579311523083191890}
+  - component: {fileID: 5270098235126350792}
+  - component: {fileID: 7875592581739494100}
+  - component: {fileID: 2740706693016462845}
+  - component: {fileID: 6232664043368435949}
+  - component: {fileID: 300508872209839503}
+  m_Layer: 0
+  m_Name: Enemy_Ranged
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5033047982814235756
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8413762502131051733}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 56, y: 1.45, z: 56.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2658241939901146667}
+  - {fileID: 1516672101405468497}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &579311523083191890
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8413762502131051733}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5270098235126350792
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8413762502131051733}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &7875592581739494100
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8413762502131051733}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!54 &2740706693016462845
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8413762502131051733}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &6232664043368435949
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8413762502131051733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 264463a6ed758824a81431e64100c27b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyType: 2
+  elementType: 0
+  primaryDamageType: 0
+  enemyName: Enemy
+  hpSlider: {fileID: 5114757515185780597}
+  hpText: {fileID: 52321937862142729}
+  hpCanvas: {fileID: 2562708966553098909}
+  damageText: {fileID: 8688029935883353112}
+  deathEffect: {fileID: 0}
+  deathSound: {fileID: 0}
+  damageEffect: {fileID: 0}
+  bulletPrefab: {fileID: 3199271071223229155, guid: 6e745beddbf77d54c9842b278bdd1f8d, type: 3}
+  firePoint: {fileID: 2658241939901146667}
+  attackRange: 8
+  attackCooldown: 2
+  attackDuration: 0.5
+  runtimeStats:
+    currentHP: 0
+    physicalDamage: 0
+    attackSpeed: 0
+    moveSpeed: 0
+--- !u!114 &300508872209839503
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8413762502131051733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aa01c0472138434e94d6ffe6d34780d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 2

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Ranged.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Ranged.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a0c8a9d20580c194bb5c1e8fdc321188
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Tanker.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Tanker.prefab
@@ -1,0 +1,821 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3106646860310795151
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3846790778676984557}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3846790778676984557
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3106646860310795151}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3971679235987399780}
+  m_Father: {fileID: 4678532065377252899}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &4096129562952446781
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 43196909368671078}
+  - component: {fileID: 5580757077288472118}
+  - component: {fileID: 3057511820396897197}
+  - component: {fileID: 4962493574487658574}
+  m_Layer: 5
+  m_Name: 'Enemy_Tanker_HP_Canvas '
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &43196909368671078
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4096129562952446781}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7371384243409464013}
+  - {fileID: 3776270494818494395}
+  - {fileID: 4678532065377252899}
+  m_Father: {fileID: 6077051408191451019}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 1}
+  m_SizeDelta: {x: 100, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &5580757077288472118
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4096129562952446781}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 10
+  m_TargetDisplay: 0
+--- !u!114 &3057511820396897197
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4096129562952446781}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!114 &4962493574487658574
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4096129562952446781}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &4659347511223523390
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3776270494818494395}
+  - component: {fileID: 7047464255732526729}
+  - component: {fileID: 4521409260539031959}
+  m_Layer: 5
+  m_Name: Enemy_Tanker_Damage_Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &3776270494818494395
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4659347511223523390}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 43196909368671078}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7047464255732526729
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4659347511223523390}
+  m_CullTransparentMesh: 1
+--- !u!114 &4521409260539031959
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4659347511223523390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: -50
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4873730282139889678
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3971679235987399780}
+  - component: {fileID: 3610448085984355946}
+  - component: {fileID: 8910155317114245593}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3971679235987399780
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4873730282139889678}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3846790778676984557}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3610448085984355946
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4873730282139889678}
+  m_CullTransparentMesh: 1
+--- !u!114 &8910155317114245593
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4873730282139889678}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5033370213045980155
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6077051408191451019}
+  - component: {fileID: 8519291174457961344}
+  - component: {fileID: 8912034381635532100}
+  - component: {fileID: 8483997091556630715}
+  - component: {fileID: 132679734436795624}
+  - component: {fileID: 7740995610691687504}
+  - component: {fileID: 3797283735399900122}
+  m_Layer: 0
+  m_Name: Enemy_Tanker
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6077051408191451019
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5033370213045980155}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 56, y: 1.17, z: 59.14}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 43196909368671078}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8519291174457961344
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5033370213045980155}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8912034381635532100
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5033370213045980155}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8cd1de915f3277b4cbdcc69e60f4bd32, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &8483997091556630715
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5033370213045980155}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &132679734436795624
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5033370213045980155}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ef9be796a31dc324594e7c395bb86785, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &7740995610691687504
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5033370213045980155}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 799e5dc42f9f4144eb2fee870a297f41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyType: 0
+  elementType: 0
+  primaryDamageType: 0
+  enemyName: Enemy
+  hpSlider: {fileID: 1266502768670754706}
+  hpText: {fileID: 2360994602832012674}
+  hpCanvas: {fileID: 5580757077288472118}
+  damageText: {fileID: 4521409260539031959}
+  deathEffect: {fileID: 0}
+  deathSound: {fileID: 0}
+  damageEffect: {fileID: 0}
+  attackDuration: 0.5
+--- !u!54 &3797283735399900122
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5033370213045980155}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!1 &5368032311816784859
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7371384243409464013}
+  - component: {fileID: 3584714469057353070}
+  - component: {fileID: 2360994602832012674}
+  m_Layer: 5
+  m_Name: Enemy_Tanker_HP_Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7371384243409464013
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5368032311816784859}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 43196909368671078}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 150, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3584714469057353070
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5368032311816784859}
+  m_CullTransparentMesh: 1
+--- !u!114 &2360994602832012674
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5368032311816784859}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 150/150
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 8
+  m_fontSizeBase: 8
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &6317603649308100630
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4678532065377252899}
+  - component: {fileID: 1266502768670754706}
+  m_Layer: 5
+  m_Name: Enemy_Tanker_HP_Slider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4678532065377252899
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6317603649308100630}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8869343349871113199}
+  - {fileID: 3846790778676984557}
+  m_Father: {fileID: 43196909368671078}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1266502768670754706
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6317603649308100630}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 0, b: 0, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 3971679235987399780}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &8794454732537358455
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8869343349871113199}
+  - component: {fileID: 7742527649947341097}
+  - component: {fileID: 8429289643937913406}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8869343349871113199
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8794454732537358455}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4678532065377252899}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7742527649947341097
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8794454732537358455}
+  m_CullTransparentMesh: 1
+--- !u!114 &8429289643937913406
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8794454732537358455}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Tanker.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Tanker.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d5f87bb6b80801348b98102703ff1d02
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Wizard.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Wizard.prefab
@@ -1,0 +1,1045 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1045485948185253385
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1742750885764851975}
+  - component: {fileID: 7702040566865229981}
+  - component: {fileID: 4764624742809656160}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1742750885764851975
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1045485948185253385}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5466692674296104290}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7702040566865229981
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1045485948185253385}
+  m_CullTransparentMesh: 1
+--- !u!114 &4764624742809656160
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1045485948185253385}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3784174612750413985
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4904640602668960989}
+  - component: {fileID: 9019783409684909316}
+  - component: {fileID: 2822821211543548083}
+  - component: {fileID: 207257605747129796}
+  m_Layer: 0
+  m_Name: Capsule
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4904640602668960989
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3784174612750413985}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8398621757576964424}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!33 &9019783409684909316
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3784174612750413985}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2822821211543548083
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3784174612750413985}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &207257605747129796
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3784174612750413985}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 0
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &4184352309707890560
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2162462161992600185}
+  - component: {fileID: 4115566889879069627}
+  - component: {fileID: 8272746215587457016}
+  m_Layer: 5
+  m_Name: Enemy_Wizard_Damage_Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &2162462161992600185
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4184352309707890560}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6653663974883641874}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4115566889879069627
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4184352309707890560}
+  m_CullTransparentMesh: 1
+--- !u!114 &8272746215587457016
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4184352309707890560}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: -50
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4292368667243411546
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1942093850744528893}
+  - component: {fileID: 8776114103961087884}
+  - component: {fileID: 2139513275792036161}
+  m_Layer: 5
+  m_Name: Enemy_Wizard_HP_Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1942093850744528893
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4292368667243411546}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6653663974883641874}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 150, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8776114103961087884
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4292368667243411546}
+  m_CullTransparentMesh: 1
+--- !u!114 &2139513275792036161
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4292368667243411546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 150/150
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 8
+  m_fontSizeBase: 8
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4306444908189541877
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6653663974883641874}
+  - component: {fileID: 5342001922245008397}
+  - component: {fileID: 2081029371234780411}
+  - component: {fileID: 2969413032692622900}
+  m_Layer: 5
+  m_Name: Enemy_Wizard_HP_Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6653663974883641874
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4306444908189541877}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1942093850744528893}
+  - {fileID: 2162462161992600185}
+  - {fileID: 5466692674296104290}
+  m_Father: {fileID: 8398621757576964424}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 2}
+  m_SizeDelta: {x: 100, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &5342001922245008397
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4306444908189541877}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 10
+  m_TargetDisplay: 0
+--- !u!114 &2081029371234780411
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4306444908189541877}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!114 &2969413032692622900
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4306444908189541877}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &5459159797311196345
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8221693790834037043}
+  - component: {fileID: 7136639224178590028}
+  - component: {fileID: 3458368202246955083}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8221693790834037043
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5459159797311196345}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8835035333905506875}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7136639224178590028
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5459159797311196345}
+  m_CullTransparentMesh: 1
+--- !u!114 &3458368202246955083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5459159797311196345}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5706290721737779469
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8398621757576964424}
+  - component: {fileID: 6218901794020339774}
+  - component: {fileID: 2172581641281684056}
+  - component: {fileID: 6306413342456423819}
+  - component: {fileID: 76854685520542485}
+  - component: {fileID: 1566943576828302240}
+  - component: {fileID: 441747294194199312}
+  m_Layer: 0
+  m_Name: Enemy_Wizard
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8398621757576964424
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5706290721737779469}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 50.55, y: 1, z: 56}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4904640602668960989}
+  - {fileID: 753733973822906777}
+  - {fileID: 6653663974883641874}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6218901794020339774
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5706290721737779469}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2172581641281684056
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5706290721737779469}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &6306413342456423819
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5706290721737779469}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!114 &76854685520542485
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5706290721737779469}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2470df3c540752447b581f9f6d3bf40f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyType: 3
+  elementType: 0
+  primaryDamageType: 1
+  enemyName: Enemy
+  hpSlider: {fileID: 8123070434288136039}
+  hpText: {fileID: 2139513275792036161}
+  hpCanvas: {fileID: 5342001922245008397}
+  damageText: {fileID: 8272746215587457016}
+  deathEffect: {fileID: 0}
+  deathSound: {fileID: 0}
+  damageEffect: {fileID: 0}
+  magicOrbPrefab: {fileID: 411572275915798111, guid: 69784a6365d5f504ca1c0a65da01dd32, type: 3}
+  castPoint: {fileID: 753733973822906777}
+  attackRange: 10
+  attackCooldown: 2.5
+  castDuration: 0.5
+  orbSpeed: 6
+--- !u!114 &1566943576828302240
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5706290721737779469}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fd1f4890d90a3b140b94ead541ea8093, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 1.8
+  optimalDistance: 8
+  repositionTime: 3
+--- !u!54 &441747294194199312
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5706290721737779469}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 4
+  m_CollisionDetection: 0
+--- !u!1 &5804174021305858457
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8835035333905506875}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8835035333905506875
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5804174021305858457}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8221693790834037043}
+  m_Father: {fileID: 5466692674296104290}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8876906887614999342
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5466692674296104290}
+  - component: {fileID: 8123070434288136039}
+  m_Layer: 5
+  m_Name: Enemy_Wizard_HP_Slider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5466692674296104290
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8876906887614999342}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1742750885764851975}
+  - {fileID: 8835035333905506875}
+  m_Father: {fileID: 6653663974883641874}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8123070434288136039
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8876906887614999342}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 0, b: 0, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 8221693790834037043}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &9009368651488848437
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 753733973822906777}
+  - component: {fileID: 303082344299157688}
+  - component: {fileID: 7610364014519108220}
+  - component: {fileID: 5934474528524668623}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &753733973822906777
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9009368651488848437}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8398621757576964424}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &303082344299157688
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9009368651488848437}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7610364014519108220
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9009368651488848437}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &5934474528524668623
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9009368651488848437}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 0
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Wizard.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Object/Enemy_Wizard.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0c62d676bc5c69349a9ef207a614ce5a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8398c1775e078444ba385e3aeb5af539
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Enemy_Ranged_Bullet.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Enemy_Ranged_Bullet.prefab
@@ -1,0 +1,151 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3199271071223229155
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8881493190307393080}
+  - component: {fileID: 533856792912799568}
+  - component: {fileID: 5113327172485606000}
+  - component: {fileID: 787786149600175358}
+  - component: {fileID: 3646308579952148124}
+  - component: {fileID: 807187357475970176}
+  m_Layer: 0
+  m_Name: Enemy_Ranged_Bullet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8881493190307393080
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3199271071223229155}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 56, y: 1.45, z: 56.4}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &533856792912799568
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3199271071223229155}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5113327172485606000
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3199271071223229155}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &787786149600175358
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3199271071223229155}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &3646308579952148124
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3199271071223229155}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c1ebcd34d8b6394685a9817d863bde8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 8
+  damage: 25
+  lifeTime: 3
+--- !u!54 &807187357475970176
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3199271071223229155}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Enemy_Ranged_Bullet.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Enemy_Ranged_Bullet.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6e745beddbf77d54c9842b278bdd1f8d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Enemy_Wizard_MagicOrb.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Enemy_Wizard_MagicOrb.prefab
@@ -1,0 +1,159 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &411572275915798111
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2390657027863901103}
+  - component: {fileID: 4110124596046085947}
+  - component: {fileID: 8828738078718356853}
+  - component: {fileID: 7881144461665410134}
+  - component: {fileID: 7538507382982112165}
+  - component: {fileID: -2841162615693573306}
+  m_Layer: 0
+  m_Name: Enemy_Wizard_MagicOrb
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2390657027863901103
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411572275915798111}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 50.65506, y: 2.7026327, z: 56.301674}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4110124596046085947
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411572275915798111}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8828738078718356853
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411572275915798111}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &7881144461665410134
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411572275915798111}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &7538507382982112165
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411572275915798111}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed8d99a2d1c28614c86d4e3638632165, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 6
+  damage: 50
+  lifeTime: 4
+  damageType: 1
+  elementType: 2
+  useAdvancedDamageSystem: 1
+  isHoming: 1
+  homingStrength: 2
+  impactEffect: {fileID: 0}
+  launchSound: {fileID: 0}
+  impactSound: {fileID: 0}
+--- !u!54 &-2841162615693573306
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411572275915798111}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Enemy_Wizard_MagicOrb.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Enemy_Wizard_MagicOrb.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 69784a6365d5f504ca1c0a65da01dd32
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e903b403109e8074e810142823d103ba
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_Bullet.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_Bullet.prefab
@@ -1,0 +1,156 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5444615153167439068
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8721042225408977994}
+  - component: {fileID: 2186439641747934119}
+  - component: {fileID: 6529920386342475163}
+  - component: {fileID: 3435026938386065004}
+  - component: {fileID: 2678192076914256434}
+  - component: {fileID: 7688302255818037334}
+  m_Layer: 0
+  m_Name: Enemy_Final_Boss_Bullet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8721042225408977994
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5444615153167439068}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2186439641747934119
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5444615153167439068}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &6529920386342475163
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5444615153167439068}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &3435026938386065004
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5444615153167439068}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &2678192076914256434
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5444615153167439068}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &7688302255818037334
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5444615153167439068}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 63e0c264f16f7784986c937113b7a851, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damage: 40
+  damageType: 1
+  elementType: 1
+  lifeTime: 5
+  hitEffect: {fileID: 0}
+  trail: {fileID: 0}
+  rotateWhileFlying: 1
+  rotationSpeed: 360

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_Bullet.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_Bullet.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6ca5e60b5516dcc41b9139b8196d4746
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_DarkFloor.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_DarkFloor.prefab
@@ -1,0 +1,106 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4119778992378760006
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5558360518046174474}
+  - component: {fileID: 5291165940493196659}
+  - component: {fileID: 5607541867316945843}
+  - component: {fileID: 5115585621763589715}
+  m_Layer: 0
+  m_Name: Enemy_Final_Boss_DarkFloor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5558360518046174474
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4119778992378760006}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -26.069633, y: -1.4116379, z: -28.23097}
+  m_LocalScale: {x: 20, y: 0.1, z: 20}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5291165940493196659
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4119778992378760006}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5607541867316945843
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4119778992378760006}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &5115585621763589715
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4119778992378760006}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ff9980c78138cc24c9ea86ed9599f4f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  floorRadius: 10
+  damageInterval: 0.5
+  followSpeed: 3
+  detectionInterval: 0.1
+  floorEffect: {fileID: 0}
+  floorLight: {fileID: 0}
+  ambientSound: {fileID: 0}
+  pulseIntensity: 0.3

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_DarkFloor.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_DarkFloor.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c3b13bb7acf8dd043be54d122769a78b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_Dark_Orb.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_Dark_Orb.prefab
@@ -1,0 +1,162 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4231158396768756967
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7843228476363867423}
+  - component: {fileID: 281135499970289848}
+  - component: {fileID: 4683548344283817498}
+  - component: {fileID: 2372685319224161023}
+  - component: {fileID: 3068370723415813780}
+  - component: {fileID: 1947205163109150661}
+  m_Layer: 0
+  m_Name: Enemy_Final_Boss_Dark_Orb
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7843228476363867423
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4231158396768756967}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 52.139267, y: 1, z: 56.46194}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &281135499970289848
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4231158396768756967}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4683548344283817498
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4231158396768756967}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &2372685319224161023
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4231158396768756967}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &3068370723415813780
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4231158396768756967}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8560a3f9318c3c24393bcfb1d67accd4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  health: 100
+  moveSpeed: 3
+  heightFixed: 1
+  minDistanceToPlayer: 6
+  maxDistanceToPlayer: 15
+  randomMoveInterval: 2
+  darkBulletPrefab: {fileID: 5444615153167439068, guid: 6ca5e60b5516dcc41b9139b8196d4746, type: 3}
+  darkBulletDamage: 40
+  darkBulletCount: 12
+  darkBulletSpeed: 8
+  darkBulletCooldown: 2
+  orbMaterial: {fileID: 0}
+  orbColor: {r: 1, g: 0, b: 0, a: 1}
+  emissionIntensity: 0.3
+--- !u!54 &1947205163109150661
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4231158396768756967}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 84
+  m_CollisionDetection: 0

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_Dark_Orb.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_Dark_Orb.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 913db6cd50cbea84f81d3a5effac3358
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_LightPillar.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_LightPillar.prefab
@@ -1,0 +1,129 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4443971174912647640
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7700913937416605688}
+  - component: {fileID: 1811426403181689066}
+  - component: {fileID: 8144703368472670424}
+  - component: {fileID: 2650808709433201441}
+  - component: {fileID: 5398624849291351623}
+  m_Layer: 0
+  m_Name: Enemy_Final_Boss_LightPillar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7700913937416605688
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4443971174912647640}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -26.069633, y: -1.4116379, z: -28.23097}
+  m_LocalScale: {x: 2, y: 3, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1811426403181689066
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4443971174912647640}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8144703368472670424
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4443971174912647640}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &2650808709433201441
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4443971174912647640}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 0
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!114 &5398624849291351623
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4443971174912647640}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8fc83a2c14f81f047b0de37b97919028, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  pillarRadius: 4
+  pillarHeight: 20
+  warningDuration: 1.5
+  activeDuration: 5
+  warningEffect: {fileID: 0}
+  pillarEffect: {fileID: 0}
+  pillarLight: {fileID: 0}

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_LightPillar.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_LightPillar.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0b4501488271ee641ba5d60d85347d53
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_Light_Orb.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_Light_Orb.prefab
@@ -1,0 +1,162 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6650104745104872665
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 502128648502592173}
+  - component: {fileID: 9118089124395687403}
+  - component: {fileID: 27457720416741421}
+  - component: {fileID: 494577263482132499}
+  - component: {fileID: 1972280816304208117}
+  - component: {fileID: 227823278827938470}
+  m_Layer: 0
+  m_Name: Enemy_Final_Boss_Light_Orb
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &502128648502592173
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6650104745104872665}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 52.139267, y: 1, z: 56.46194}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &9118089124395687403
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6650104745104872665}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &27457720416741421
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6650104745104872665}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &494577263482132499
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6650104745104872665}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &1972280816304208117
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6650104745104872665}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7057318f64b9641948ac0c92e61b3d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  health: 100
+  moveSpeed: 10
+  heightFixed: 1
+  minDistanceToPlayer: 1
+  maxDistanceToPlayer: 3
+  randomMoveInterval: 5
+  railgunBeamPrefab: {fileID: 6505944401630606831, guid: 4a9fa4887c200864f97716aa133f382f, type: 3}
+  railgunDamage: 120
+  railgunChargeTime: 2
+  railgunCooldown: 4
+  orbMaterial: {fileID: 0}
+  orbColor: {r: 1, g: 1, b: 1, a: 1}
+  emissionIntensity: 0.5
+  chargingEffect: {fileID: 0}
+--- !u!54 &227823278827938470
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6650104745104872665}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_Light_Orb.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_Light_Orb.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a0ceec0a13e4e594e94dc3bfe1a6021e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_PullBullet.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_PullBullet.prefab
@@ -1,0 +1,154 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6546361683439244877
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1904836926612701152}
+  - component: {fileID: 4415920604235109438}
+  - component: {fileID: 8931834048560692191}
+  - component: {fileID: 8070451895696726503}
+  - component: {fileID: 2968525172937632528}
+  - component: {fileID: 5132235763591207581}
+  m_Layer: 0
+  m_Name: Enemy_Final_Boss_PullBullet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1904836926612701152
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6546361683439244877}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 44.662937, y: 2, z: 75.52116}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4415920604235109438
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6546361683439244877}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8931834048560692191
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6546361683439244877}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &8070451895696726503
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6546361683439244877}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &2968525172937632528
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6546361683439244877}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 11f91ddafa7caf0468da0b0294700abf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxLifetime: 60
+  pullRadius: 3
+  pullDuration: 0.5
+  cooldownAfterHit: 3
+  bulletLight: {fileID: 0}
+  hitSound: {fileID: 0}
+--- !u!54 &5132235763591207581
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6546361683439244877}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_PullBullet.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_PullBullet.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f05aaaaa332ccd14e88351e76c18eaba
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_RailgunBeam.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_RailgunBeam.prefab
@@ -1,0 +1,747 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3265416460686465373
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2943093925032071907}
+  - component: {fileID: 4856778195730719689}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2943093925032071907
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3265416460686465373}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 66.99441, y: 3, z: 113.28174}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5076413788928001729}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!120 &4856778195730719689
+LineRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3265416460686465373}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8cd1de915f3277b4cbdcc69e60f4bd32, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Positions:
+  - {x: 1, y: 1, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1.4551454
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 0.99045753, g: 1, b: 0, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: 0
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 1
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_MaskInteraction: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
+--- !u!1 &4530309939458551542
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5578665876632747015}
+  - component: {fileID: 70263403372445766}
+  m_Layer: 0
+  m_Name: GameObject (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5578665876632747015
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4530309939458551542}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 66.99441, y: 3, z: 113.28174}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5076413788928001729}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!120 &70263403372445766
+LineRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4530309939458551542}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8cd1de915f3277b4cbdcc69e60f4bd32, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Positions:
+  - {x: 1, y: 1, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1.4551454
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 0.99045753, g: 1, b: 0, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: 0
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 1
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_MaskInteraction: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
+--- !u!1 &6505944401630606831
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5076413788928001729}
+  - component: {fileID: 8764265426691011438}
+  m_Layer: 0
+  m_Name: Enemy_Final_Boss_RailgunBeam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5076413788928001729
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6505944401630606831}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.6666667, y: 0.6666667, z: 0.6666667}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2943093925032071907}
+  - {fileID: 5692096588902706061}
+  - {fileID: 5578665876632747015}
+  - {fileID: 3559009836815169869}
+  - {fileID: 100120859648517631}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8764265426691011438
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6505944401630606831}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b7e3a58b20d2cf14ba6e8b0fadca149c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damage: 120
+  maxRange: 30
+  beamWidth: 0.5
+  chargingTime: 0.5
+  beamDuration: 1
+  damageType: 1
+  elementType: 0
+  canPenetrate: 0
+  beamAngles:
+  - 0
+  - -15
+  - 15
+  - -30
+  - 30
+  centerBeam: {fileID: 4856778195730719689}
+  leftBeam1: {fileID: 5473040775535195344}
+  rightBeam1: {fileID: 70263403372445766}
+  leftBeam2: {fileID: 960113499179700694}
+  rightBeam2: {fileID: 1710057909019382166}
+  chargingParticle: {fileID: 0}
+  fireSound: {fileID: 0}
+--- !u!1 &7960413644409600475
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100120859648517631}
+  - component: {fileID: 1710057909019382166}
+  m_Layer: 0
+  m_Name: GameObject (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100120859648517631
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7960413644409600475}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 66.99441, y: 3, z: 113.28174}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5076413788928001729}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!120 &1710057909019382166
+LineRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7960413644409600475}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8cd1de915f3277b4cbdcc69e60f4bd32, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Positions:
+  - {x: 1, y: 1, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1.4551454
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 0.99045753, g: 1, b: 0, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: 0
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 1
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_MaskInteraction: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
+--- !u!1 &8243314005404161100
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5692096588902706061}
+  - component: {fileID: 5473040775535195344}
+  m_Layer: 0
+  m_Name: GameObject (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5692096588902706061
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8243314005404161100}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 66.99441, y: 3, z: 113.28174}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5076413788928001729}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!120 &5473040775535195344
+LineRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8243314005404161100}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8cd1de915f3277b4cbdcc69e60f4bd32, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Positions:
+  - {x: 1, y: 1, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1.4551454
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 0.99045753, g: 1, b: 0, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: 0
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 1
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_MaskInteraction: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
+--- !u!1 &8718064568876788500
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3559009836815169869}
+  - component: {fileID: 960113499179700694}
+  m_Layer: 0
+  m_Name: GameObject (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3559009836815169869
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8718064568876788500}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 66.99441, y: 3, z: 113.28174}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5076413788928001729}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!120 &960113499179700694
+LineRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8718064568876788500}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8cd1de915f3277b4cbdcc69e60f4bd32, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Positions:
+  - {x: 1, y: 1, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1.4551454
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 0.99045753, g: 1, b: 0, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: 0
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 1
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_MaskInteraction: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_RailgunBeam.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_RailgunBeam.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4a9fa4887c200864f97716aa133f382f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_SwordBeam.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_SwordBeam.prefab
@@ -1,0 +1,155 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4366707699226452152
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3660991303670046063}
+  - component: {fileID: 6064191197749829918}
+  - component: {fileID: 1063811783575337212}
+  - component: {fileID: 6733226753947649455}
+  - component: {fileID: 7510697117570656479}
+  - component: {fileID: 8659443589546130695}
+  m_Layer: 0
+  m_Name: Enemy_Final_Boss_SwordBeam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3660991303670046063
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4366707699226452152}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 4}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6064191197749829918
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4366707699226452152}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1063811783575337212
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4366707699226452152}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &6733226753947649455
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4366707699226452152}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &7510697117570656479
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4366707699226452152}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &8659443589546130695
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4366707699226452152}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67902e394f927a2428cf8420d0c84935, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  beamLength: 3
+  beamWidth: 1.5
+  expandSpeed: 8
+  sustainTime: 0.3
+  beamLine: {fileID: 0}
+  beamLight: {fileID: 0}
+  slashSound: {fileID: 0}

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_SwordBeam.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/FinalBoss/Enemy_Final_Boss_SwordBeam.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ecbc102024c96f9499bf8b8a5518cfdb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: beaf1ed071c40924eafce2534173818e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss2_Bullet.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss2_Bullet.prefab
@@ -1,0 +1,154 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4977601195752174484
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2101912912856153550}
+  - component: {fileID: 4413141133103724250}
+  - component: {fileID: 5212643365417514444}
+  - component: {fileID: 2338676448568311332}
+  - component: {fileID: 2442957202058616516}
+  - component: {fileID: 4895634631913575110}
+  m_Layer: 0
+  m_Name: Enemy_Middle_Boss2_Bullet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2101912912856153550
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4977601195752174484}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 52.139267, y: 0.3534485, z: 56.46194}
+  m_LocalScale: {x: 5, y: 5, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4413141133103724250
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4977601195752174484}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5212643365417514444
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4977601195752174484}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &2338676448568311332
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4977601195752174484}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &2442957202058616516
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4977601195752174484}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &4895634631913575110
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4977601195752174484}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6124b13501b36543ac44822d09e58a2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damage: 20
+  damageType: 1
+  elementType: 1
+  lifeTime: 0.3
+  hitEffect: {fileID: 0}
+  trail: {fileID: 0}

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss2_Bullet.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss2_Bullet.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6f453bba8e922084283422e4dd08c4c4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss_Bullet.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss_Bullet.prefab
@@ -1,0 +1,154 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4549591371034847080
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4264886747520955526}
+  - component: {fileID: 3309989650723134846}
+  - component: {fileID: 1848426316958130055}
+  - component: {fileID: 5326827489557376143}
+  - component: {fileID: 2935714465560464311}
+  - component: {fileID: 3890765215269485181}
+  m_Layer: 0
+  m_Name: Enemy_Middle_Boss_Bullet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4264886747520955526
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4549591371034847080}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 52.139267, y: 0.3534485, z: 56.46194}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3309989650723134846
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4549591371034847080}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1848426316958130055
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4549591371034847080}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &5326827489557376143
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4549591371034847080}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &2935714465560464311
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4549591371034847080}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &3890765215269485181
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4549591371034847080}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6124b13501b36543ac44822d09e58a2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damage: 20
+  damageType: 1
+  elementType: 1
+  lifeTime: 3
+  hitEffect: {fileID: 0}
+  trail: {fileID: 0}

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss_Bullet.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss_Bullet.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4cffd1d870a7cb04d909d47c2c5af07b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss_FloorHazard.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss_FloorHazard.prefab
@@ -1,0 +1,129 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6559232480380340793
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6759459157960488677}
+  - component: {fileID: 2054754934291591826}
+  - component: {fileID: 5218825590067261455}
+  - component: {fileID: 4830219036852216462}
+  - component: {fileID: 8778997118876744032}
+  m_Layer: 0
+  m_Name: Enemy_Middle_Boss_FloorHazard
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6759459157960488677
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6559232480380340793}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 52.139267, y: 0.3534485, z: 56.46194}
+  m_LocalScale: {x: 8, y: 0.5, z: 8}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2054754934291591826
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6559232480380340793}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5218825590067261455
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6559232480380340793}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &4830219036852216462
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6559232480380340793}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &8778997118876744032
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6559232480380340793}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fd743222a87d1724fa5fc061a5376ff1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damageInterval: 0.5
+  warningDuration: 1
+  playerLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  warningEffect: {fileID: 0}
+  hazardEffect: {fileID: 0}
+  warningSound: {fileID: 0}
+  activateSound: {fileID: 0}

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss_FloorHazard.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss_FloorHazard.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9ef1a1d14d1b04f47a41998690746665
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss_Grab.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss_Grab.prefab
@@ -1,0 +1,155 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3977941196133518516
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7791726543278567420}
+  - component: {fileID: 3124033157137938857}
+  - component: {fileID: 2867780081963113408}
+  - component: {fileID: 3035721548417436342}
+  - component: {fileID: 6220953258502308118}
+  - component: {fileID: 8300366978808338720}
+  m_Layer: 0
+  m_Name: Enemy_Middle_Boss_Grab
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7791726543278567420
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3977941196133518516}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 52.139267, y: 0.3534485, z: 56.46194}
+  m_LocalScale: {x: 2, y: 2, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3124033157137938857
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3977941196133518516}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2867780081963113408
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3977941196133518516}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &3035721548417436342
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3977941196133518516}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.5, y: 1.5, z: 0.5}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &6220953258502308118
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3977941196133518516}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &8300366978808338720
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3977941196133518516}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3bea17bf4e7495e478113b547792ced1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  pullForce: 8
+  pullDuration: 2
+  damage: 40
+  lifeTime: 5
+  hitEffect: {fileID: 0}
+  trail: {fileID: 0}
+  grabEffect: {fileID: 0}

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss_Grab.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_Projectiles/Middle_Boss/Enemy_Middle_Boss_Grab.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9dcf57a9cfbf5b441a7ec893498fec16
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_UI.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8ff232a496f09e146a820110aa8149a5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_UI/Enemy_Boss_HP_Canvas.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_UI/Enemy_Boss_HP_Canvas.prefab
@@ -1,0 +1,778 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &423172130561321881
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8712436267875171931}
+  - component: {fileID: 8361626334219400418}
+  - component: {fileID: 6751335640589905205}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8712436267875171931
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 423172130561321881}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8480484240706112570}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8361626334219400418
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 423172130561321881}
+  m_CullTransparentMesh: 1
+--- !u!114 &6751335640589905205
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 423172130561321881}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &563530784247307188
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6572477068778555381}
+  - component: {fileID: 5022945011288225177}
+  m_Layer: 5
+  m_Name: Enemy_Boss_HP_Slider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6572477068778555381
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 563530784247307188}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4830408915809984981}
+  - {fileID: 7793613316412324491}
+  - {fileID: 8480484240706112570}
+  m_Father: {fileID: 3776164074841878250}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -30}
+  m_SizeDelta: {x: 700, y: 25}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5022945011288225177
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 563530784247307188}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6751335640589905205}
+  m_FillRect: {fileID: 237462176129943191}
+  m_HandleRect: {fileID: 8712436267875171931}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &1490054867214302677
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3776164074841878250}
+  - component: {fileID: 8049723155580537977}
+  - component: {fileID: 394718847288234248}
+  m_Layer: 5
+  m_Name: Enemy_Boss_HP_Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3776164074841878250
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1490054867214302677}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3092702098861794408}
+  - {fileID: 7464113593894059827}
+  - {fileID: 6572477068778555381}
+  m_Father: {fileID: 3311367466543268634}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -50}
+  m_SizeDelta: {x: 800, y: 120}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8049723155580537977
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1490054867214302677}
+  m_CullTransparentMesh: 1
+--- !u!114 &394718847288234248
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1490054867214302677}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1966717871863318255
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3092702098861794408}
+  - component: {fileID: 878740949687214443}
+  - component: {fileID: 1930120291514498424}
+  m_Layer: 5
+  m_Name: Enemy_Boss_Name_Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3092702098861794408
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1966717871863318255}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3776164074841878250}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: 600, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &878740949687214443
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1966717871863318255}
+  m_CullTransparentMesh: 1
+--- !u!114 &1930120291514498424
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1966717871863318255}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Middle_Boss
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28
+  m_fontSizeBase: 28
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1981577893780808514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3311367466543268634}
+  - component: {fileID: 8707500126718502160}
+  - component: {fileID: 1259861013954686412}
+  - component: {fileID: 701913973997377032}
+  m_Layer: 5
+  m_Name: Enemy_Boss_HP_Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3311367466543268634
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1981577893780808514}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3776164074841878250}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &8707500126718502160
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1981577893780808514}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &1259861013954686412
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1981577893780808514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!114 &701913973997377032
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1981577893780808514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &2317614644766444543
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7793613316412324491}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7793613316412324491
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2317614644766444543}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 237462176129943191}
+  m_Father: {fileID: 6572477068778555381}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2440047498370435679
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8480484240706112570}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8480484240706112570
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2440047498370435679}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8712436267875171931}
+  m_Father: {fileID: 6572477068778555381}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &3986850863386465626
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 237462176129943191}
+  - component: {fileID: 6453241628792749500}
+  - component: {fileID: 5437316511181535432}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &237462176129943191
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3986850863386465626}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7793613316412324491}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6453241628792749500
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3986850863386465626}
+  m_CullTransparentMesh: 1
+--- !u!114 &5437316511181535432
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3986850863386465626}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5628882578080405296
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7464113593894059827}
+  - component: {fileID: 9183570760601528250}
+  - component: {fileID: 8274186667146651681}
+  m_Layer: 5
+  m_Name: Enemy_Boss_HP_Border
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7464113593894059827
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5628882578080405296}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3776164074841878250}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -30}
+  m_SizeDelta: {x: 710, y: 35}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9183570760601528250
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5628882578080405296}
+  m_CullTransparentMesh: 1
+--- !u!114 &8274186667146651681
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5628882578080405296}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.7513621, g: 0.7660377, b: 0.42637944, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7994798352019359098
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4830408915809984981}
+  - component: {fileID: 1002634716221866980}
+  - component: {fileID: 6348374839300526808}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4830408915809984981
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7994798352019359098}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6572477068778555381}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1002634716221866980
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7994798352019359098}
+  m_CullTransparentMesh: 1
+--- !u!114 &6348374839300526808
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7994798352019359098}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_UI/Enemy_Boss_HP_Canvas.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_UI/Enemy_Boss_HP_Canvas.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a5f1b1e60e93cf644b2b087df57b14eb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_UI/Enemy_HP_Canvas.prefab
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_UI/Enemy_HP_Canvas.prefab
@@ -1,0 +1,649 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &529173117503471386
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5163431827562432410}
+  - component: {fileID: 1788049374535275329}
+  - component: {fileID: 4947703140975962130}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5163431827562432410
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 529173117503471386}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5598793574063824659}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1788049374535275329
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 529173117503471386}
+  m_CullTransparentMesh: 1
+--- !u!114 &4947703140975962130
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 529173117503471386}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &947068298255931279
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3271775307551517491}
+  - component: {fileID: 1675538329623326771}
+  - component: {fileID: 5817001126496162723}
+  m_Layer: 5
+  m_Name: Enemy_HP_Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3271775307551517491
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 947068298255931279}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5224300981434332915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 150, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1675538329623326771
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 947068298255931279}
+  m_CullTransparentMesh: 1
+--- !u!114 &5817001126496162723
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 947068298255931279}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 150/150
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 8
+  m_fontSizeBase: 8
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4332213721447567278
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5598793574063824659}
+  - component: {fileID: 5539655217311166684}
+  m_Layer: 5
+  m_Name: Enemy_HP_Slider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5598793574063824659
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4332213721447567278}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5163431827562432410}
+  - {fileID: 9137548936036735979}
+  m_Father: {fileID: 5224300981434332915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5539655217311166684
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4332213721447567278}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 0, b: 0, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 189285232674083542}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &5720975564599484361
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5224300981434332915}
+  - component: {fileID: 5653694854048620947}
+  - component: {fileID: 3449299857475394903}
+  - component: {fileID: 1808325187391215012}
+  m_Layer: 5
+  m_Name: Enemy_HP_Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5224300981434332915
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5720975564599484361}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3271775307551517491}
+  - {fileID: 5081519581431179418}
+  - {fileID: 5598793574063824659}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &5653694854048620947
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5720975564599484361}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 10
+  m_TargetDisplay: 0
+--- !u!114 &3449299857475394903
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5720975564599484361}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!114 &1808325187391215012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5720975564599484361}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &6965302915320491263
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 189285232674083542}
+  - component: {fileID: 2562557422053196988}
+  - component: {fileID: 8893445153261826598}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &189285232674083542
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6965302915320491263}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9137548936036735979}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2562557422053196988
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6965302915320491263}
+  m_CullTransparentMesh: 1
+--- !u!114 &8893445153261826598
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6965302915320491263}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8094185824851199119
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9137548936036735979}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9137548936036735979
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8094185824851199119}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 189285232674083542}
+  m_Father: {fileID: 5598793574063824659}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8656581138323801073
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5081519581431179418}
+  - component: {fileID: 646382351053213495}
+  - component: {fileID: 4037502189212948538}
+  m_Layer: 5
+  m_Name: Enemy_Damage_Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &5081519581431179418
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8656581138323801073}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5224300981434332915}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &646382351053213495
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8656581138323801073}
+  m_CullTransparentMesh: 1
+--- !u!114 &4037502189212948538
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8656581138323801073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: -50
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}

--- a/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_UI/Enemy_HP_Canvas.prefab.meta
+++ b/Lunebris/Assets/Resources/Prefabs/Enemy/Enemy_UI/Enemy_HP_Canvas.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dd35266ac007eba4287c4e9112ff5b29
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 52e94d526b33e2f41916c5ea7e50eab4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Dark.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Dark.cs
@@ -1,0 +1,672 @@
+using UnityEngine;
+using Enemy;
+using System.Collections;
+using System.Collections.Generic;
+
+/// <summary>
+/// 탄막 패턴 종류
+/// </summary>
+public enum BulletPattern
+{
+    Straight,   // 직선 공격
+    Circular,   // 원형 공격  
+    Spiral,     // 나선형 공격
+    Fan,        // 부채꼴 공격
+    Homing,     // 유도탄 공격
+    Burst       // 폭발 공격
+}
+
+/// <summary>
+/// 최종보스 - 어둠 모드 (끌어당김 탄환, 어둠 바닥, 보스 탄환) - 중간보스 패턴 적용
+/// </summary>
+[DisallowMultipleComponent]
+public class Enemy_Final_Boss_Dark : Enemy_Base
+{
+    [Header("끌어당김 탄환")]
+    [SerializeField] private GameObject pullBulletPrefab;
+    [SerializeField] private float pullBulletSpeed = 10f;
+    [SerializeField] private int pullBulletSpawnCount = 16;
+    [SerializeField] private float mapRadius = 20f;
+    [SerializeField] private float pullBulletSpawnInterval = 8f;
+    [SerializeField] private float pullBulletRange = 25f;
+
+    [Header("어둠 바닥")]
+    [SerializeField] private GameObject darkFloorHazardPrefab;
+    [SerializeField] private float darkFloorDamage = 30f;
+    [SerializeField] private float darkFloorCooldown = 5f;
+
+    [Header("보스 탄환")]
+    [SerializeField] private GameObject bossBulletPrefab;
+    [SerializeField] private float bossBulletDamage = 50f;
+    [SerializeField] private float bossBulletCooldown = 3f;
+    [SerializeField] private int bossBulletCount = 8;
+    [SerializeField] private float bossBulletRange = 15f;
+    [SerializeField] private float bossBulletSpeed = 12f;
+
+    [Header("탄막 패턴 설정")]
+    [SerializeField] private BulletPattern[] bulletPatterns;
+    [SerializeField] private float patternSwitchChance = 0.3f; // 30% 확률로 패턴 변경
+
+    [Header("이펙트")]
+    [SerializeField] private GameObject pullBulletChargeEffect;
+    [SerializeField] private GameObject darkFloorEffect;
+
+    // 상태 플래그 (중간보스 패턴)
+    private bool isCreatingPullBullets = false;
+    private bool isCreatingDarkFloor = false;
+    private bool isShootingBossBullets = false;
+
+    // 공격 타이밍 관리
+    private float lastPullBulletTime = 0f;
+    private float lastDarkFloorTime = 0f;
+    private float lastBossBulletTime = 0f;
+
+    // 활성 오브젝트 관리
+    private List<GameObject> activePullBullets = new();
+    private GameObject activeDarkFloorHazard;
+    private Coroutine pullBulletSpawnRoutine;
+
+    // 탄막 패턴 관리
+    private BulletPattern currentBulletPattern = BulletPattern.Straight;
+    private int consecutiveAttacks = 0;
+
+    // 공개 프로퍼티 (Move 스크립트에서 참조 가능)
+    public bool IsCreatingPullBullets => isCreatingPullBullets;
+    public bool IsCreatingDarkFloor => isCreatingDarkFloor;
+    public bool IsShootingBossBullets => isShootingBossBullets;
+
+    protected override void Awake()
+    {
+        enemyType = EnemyType.FinalBoss;
+        elementType = ElementType.Dark;
+        primaryDamageType = DamageType.Magical;
+        enemyName = "Dark Sovereign";
+
+        base.Awake();
+    }
+
+    protected override void InitializeEnemy()
+    {
+        base.InitializeEnemy();
+        Debug.Log("어둠 모드 보스 활성화! 어둠의 힘을 사용합니다.");
+
+        InitializeDarkMode();
+    }
+
+    public void SetHealth(float health)
+    {
+        currentHp = health;
+        UpdateHpUI();
+    }
+
+    private void InitializeDarkMode()
+    {
+        // 어둠 바닥 해저드 생성
+        CreateDarkFloorHazard();
+
+        // 주기적인 끌어당김 탄환 시스템 시작
+        pullBulletSpawnRoutine = StartCoroutine(SpawnPullBulletsPeriodically());
+
+        // 연속 공격 루틴 시작
+        StartCoroutine(ContinuousAttackRoutine());
+    }
+
+    protected override void UpdateBehavior()
+    {
+        if (playerTransform == null) return;
+
+        float distanceToPlayer = GetDistanceToPlayer();
+
+        // 공격 우선순위 (거리별로 중간보스 패턴 적용)
+        if (distanceToPlayer >= pullBulletRange * 0.8f && CanUsePullBullets())
+        {
+            // 원거리에서 끌어당김 탄환 사용
+            StartCoroutine(CreatePullBulletsAttack());
+        }
+        else if (distanceToPlayer <= bossBulletRange && CanUseBossBullets())
+        {
+            // 중거리에서 보스 탄환 사용
+            StartCoroutine(PerformBossBulletAttack());
+        }
+        else if (CanUseDarkFloor())
+        {
+            // 어둠 바닥 재생성
+            StartCoroutine(RefreshDarkFloorAttack());
+        }
+    }
+
+    protected override void UpdateMovement()
+    {
+        // Enemy_Final_Boss_Dark_Move에서 처리
+    }
+
+    protected override void PerformAttack()
+    {
+        // 기본 공격은 사용하지 않음
+    }
+
+    #region 연속 공격 시스템
+
+    private IEnumerator ContinuousAttackRoutine()
+    {
+        while (currentHp > 0)
+        {
+            // 지속적인 보스 탄환 공격 (기본 공격)
+            if (!IsPerformingAnyAttack() && playerTransform != null)
+            {
+                float distanceToPlayer = GetDistanceToPlayer();
+                if (distanceToPlayer <= bossBulletRange)
+                {
+                    yield return StartCoroutine(PerformBossBulletAttack());
+                }
+            }
+
+            yield return new WaitForSeconds(2f);
+        }
+    }
+
+    private bool IsPerformingAnyAttack()
+    {
+        return isCreatingPullBullets || isCreatingDarkFloor || isShootingBossBullets;
+    }
+
+    #endregion
+
+    #region 탄환 생성 헬퍼 메서드
+
+    private void CreateBossBullet(Vector3 direction, float speed)
+    {
+        if (bossBulletPrefab != null)
+        {
+            GameObject bullet = Instantiate(bossBulletPrefab, transform.position, Quaternion.LookRotation(direction));
+            Enemy_Final_Boss_Bullet bulletScript = bullet.GetComponent<Enemy_Final_Boss_Bullet>();
+            if (bulletScript != null)
+            {
+                bulletScript.Initialize(bossBulletDamage, direction * speed);
+            }
+        }
+        else
+        {
+            CreateTempBossBullet(direction, speed);
+        }
+    }
+
+    private void CreateHomingBullet(Vector3 initialDirection)
+    {
+        if (bossBulletPrefab != null)
+        {
+            GameObject bullet = Instantiate(bossBulletPrefab, transform.position, Quaternion.LookRotation(initialDirection));
+
+            // 유도탄 스크립트 추가 (임시로 일반 탄환으로 대체)
+            Enemy_Final_Boss_Bullet bulletScript = bullet.GetComponent<Enemy_Final_Boss_Bullet>();
+            if (bulletScript != null)
+            {
+                bulletScript.Initialize(bossBulletDamage * 1.5f, initialDirection * bossBulletSpeed * 0.8f);
+            }
+
+            // 유도탄 표시를 위해 색상 변경
+            Renderer renderer = bullet.GetComponent<Renderer>();
+            if (renderer != null)
+            {
+                Material mat = renderer.material;
+                mat.color = Color.red;
+                mat.EnableKeyword("_EMISSION");
+                mat.SetColor("_EmissionColor", Color.red * 2f);
+            }
+        }
+        else
+        {
+            CreateTempHomingBullet(initialDirection);
+        }
+    }
+
+    private void CreateTempBossBullet(Vector3 dir, float speed)
+    {
+        GameObject bullet = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        bullet.name = "TempBossBullet";
+        bullet.transform.position = transform.position;
+        bullet.transform.localScale = Vector3.one * 0.6f;
+
+        var renderer = bullet.GetComponent<Renderer>();
+        var mat = new Material(Shader.Find("Standard"))
+        {
+            color = new Color(0.3f, 0f, 0.5f)
+        };
+        mat.EnableKeyword("_EMISSION");
+        mat.SetColor("_EmissionColor", Color.magenta);
+        renderer.material = mat;
+
+        Rigidbody rb = bullet.AddComponent<Rigidbody>();
+        rb.useGravity = false;
+        rb.velocity = dir * speed;
+
+        bullet.GetComponent<Collider>().isTrigger = true;
+        bullet.AddComponent<Enemy_Temp_Damage_Projectile>().Initialize(bossBulletDamage, "보스 탄환");
+
+        Destroy(bullet, 5f);
+    }
+
+    private void CreateTempHomingBullet(Vector3 initialDirection)
+    {
+        GameObject bullet = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        bullet.name = "TempHomingBullet";
+        bullet.transform.position = transform.position;
+        bullet.transform.localScale = Vector3.one * 0.8f;
+
+        var renderer = bullet.GetComponent<Renderer>();
+        var mat = new Material(Shader.Find("Standard"))
+        {
+            color = Color.red
+        };
+        mat.EnableKeyword("_EMISSION");
+        mat.SetColor("_EmissionColor", Color.red * 3f);
+        renderer.material = mat;
+
+        Rigidbody rb = bullet.AddComponent<Rigidbody>();
+        rb.useGravity = false;
+        rb.velocity = initialDirection * bossBulletSpeed * 0.8f;
+
+        bullet.GetComponent<Collider>().isTrigger = true;
+        bullet.AddComponent<Enemy_Temp_Damage_Projectile>().Initialize(bossBulletDamage * 1.5f, "유도 탄환");
+
+        Destroy(bullet, 8f);
+    }
+
+    #endregion
+
+    #region 주기적 끌어당김 탄환 시스템
+
+    private IEnumerator SpawnPullBulletsPeriodically()
+    {
+        yield return new WaitForSeconds(pullBulletSpawnInterval);
+
+        while (currentHp > 0)
+        {
+            if (!IsPerformingAnyAttack())
+            {
+                CleanupOldPullBullets();
+                yield return CreatePullBullets();
+            }
+
+            yield return new WaitForSeconds(pullBulletSpawnInterval);
+        }
+    }
+
+    private void CleanupOldPullBullets()
+    {
+        activePullBullets.RemoveAll(b => b == null);
+        int overflow = activePullBullets.Count - pullBulletSpawnCount;
+
+        for (int i = 0; i < overflow; i++)
+        {
+            if (activePullBullets[i] != null)
+            {
+                Destroy(activePullBullets[i]);
+            }
+        }
+
+        if (overflow > 0)
+            activePullBullets.RemoveRange(0, overflow);
+    }
+
+    #endregion
+
+    #region 끌어당김 탄환 공격
+
+    private bool CanUsePullBullets()
+    {
+        return Time.time - lastPullBulletTime >= pullBulletSpawnInterval * 0.5f &&
+               !IsPerformingAnyAttack();
+    }
+
+    private IEnumerator CreatePullBulletsAttack()
+    {
+        isCreatingPullBullets = true;
+        lastPullBulletTime = Time.time;
+
+        // 차징 이펙트
+        GameObject chargeEffect = null;
+        if (pullBulletChargeEffect != null)
+        {
+            chargeEffect = Instantiate(pullBulletChargeEffect, transform.position + Vector3.up * 3f, Quaternion.identity);
+        }
+
+        yield return new WaitForSeconds(1f);
+
+        if (chargeEffect != null)
+        {
+            Destroy(chargeEffect);
+        }
+
+        yield return CreatePullBullets();
+        isCreatingPullBullets = false;
+    }
+
+    private IEnumerator CreatePullBullets()
+    {
+        if (playerTransform == null || pullBulletPrefab == null) yield break;
+
+        Vector3 playerPos = playerTransform.position;
+        Vector3 bossPos = transform.position;
+
+        // 보스 -> 플레이어 방향
+        Vector3 bossToPlayer = (playerPos - bossPos).normalized;
+
+        float angleStep = 120f / (pullBulletSpawnCount - 1);
+
+        for (int i = 0; i < pullBulletSpawnCount; i++)
+        {
+            float angle = -60f + angleStep * i;
+
+            // 플레이어 뒤쪽에 탄환 생성 (보스와 반대 방향)
+            Vector3 rotatedDir = Quaternion.Euler(0, angle, 0) * bossToPlayer;
+            Vector3 spawnPos = playerPos + rotatedDir * mapRadius;
+            spawnPos.y = 2f;
+
+            // 탄환이 보스 방향으로 날아가도록 설정
+            Vector3 toBoss = (bossPos - spawnPos).normalized;
+
+            GameObject bullet = Instantiate(pullBulletPrefab, spawnPos, Quaternion.LookRotation(toBoss));
+            bullet.GetComponent<Enemy_Final_Boss_PullBullet>()?.Initialize(toBoss, pullBulletSpeed, 15f, bossPos);
+
+            activePullBullets.Add(bullet);
+            yield return new WaitForSeconds(0.1f);
+        }
+    }
+
+    #endregion
+
+    #region 어둠 바닥 해저드
+
+    private bool CanUseDarkFloor()
+    {
+        return Time.time - lastDarkFloorTime >= darkFloorCooldown &&
+               !IsPerformingAnyAttack() &&
+               activeDarkFloorHazard == null;
+    }
+
+    private IEnumerator RefreshDarkFloorAttack()
+    {
+        isCreatingDarkFloor = true;
+        lastDarkFloorTime = Time.time;
+
+        yield return new WaitForSeconds(0.5f);
+
+        CreateDarkFloorHazard();
+
+        yield return new WaitForSeconds(0.5f);
+        isCreatingDarkFloor = false;
+    }
+
+    private void CreateDarkFloorHazard()
+    {
+        if (darkFloorHazardPrefab == null) return;
+
+        // 기존 어둠 바닥 제거
+        if (activeDarkFloorHazard != null)
+        {
+            Destroy(activeDarkFloorHazard);
+        }
+
+        activeDarkFloorHazard = Instantiate(darkFloorHazardPrefab, transform.position, Quaternion.identity);
+
+        Enemy_Final_Boss_DarkFloor darkFloorScript = activeDarkFloorHazard.GetComponent<Enemy_Final_Boss_DarkFloor>();
+        if (darkFloorScript != null)
+        {
+            darkFloorScript.Initialize(darkFloorDamage, transform);
+        }
+
+        // 이펙트 생성
+        if (darkFloorEffect != null)
+        {
+            GameObject effect = Instantiate(darkFloorEffect, transform.position, Quaternion.identity);
+            Destroy(effect, 2f);
+        }
+    }
+
+    #endregion
+
+    #region 보스 탄환 공격
+
+    private bool CanUseBossBullets()
+    {
+        return Time.time - lastBossBulletTime >= bossBulletCooldown &&
+               !IsPerformingAnyAttack();
+    }
+
+    private IEnumerator PerformBossBulletAttack()
+    {
+        isShootingBossBullets = true;
+        lastBossBulletTime = Time.time;
+
+        if (playerTransform == null)
+        {
+            isShootingBossBullets = false;
+            yield break;
+        }
+
+        // 패턴 선택 (랜덤하게 변경하거나 연속 공격 횟수에 따라)
+        SelectBulletPattern();
+
+        // 선택된 패턴에 따라 공격 실행
+        switch (currentBulletPattern)
+        {
+            case BulletPattern.Straight:
+                yield return StraightBulletAttack();
+                break;
+            case BulletPattern.Circular:
+                yield return CircularBulletAttack();
+                break;
+            case BulletPattern.Spiral:
+                yield return SpiralBulletAttack();
+                break;
+            case BulletPattern.Fan:
+                yield return FanBulletAttack();
+                break;
+            case BulletPattern.Homing:
+                yield return HomingBulletAttack();
+                break;
+            case BulletPattern.Burst:
+                yield return BurstBulletAttack();
+                break;
+        }
+
+        consecutiveAttacks++;
+        isShootingBossBullets = false;
+    }
+
+    private void SelectBulletPattern()
+    {
+        // 체력이 낮을수록 더 위험한 패턴 사용
+        float healthPercent = currentHp / enemyStats.Get(EnemyStatType.MaxHp);
+
+        if (Random.value < patternSwitchChance || consecutiveAttacks >= 3)
+        {
+            if (healthPercent > 0.7f)
+            {
+                // 체력 70% 이상: 기본 패턴들
+                currentBulletPattern = (BulletPattern)Random.Range(0, 3);
+            }
+            else if (healthPercent > 0.4f)
+            {
+                // 체력 40-70%: 중급 패턴들
+                currentBulletPattern = (BulletPattern)Random.Range(1, 5);
+            }
+            else
+            {
+                // 체력 40% 이하: 모든 패턴 (위험!)
+                currentBulletPattern = (BulletPattern)Random.Range(2, 6);
+            }
+
+            consecutiveAttacks = 0;
+            Debug.Log($"다크 보스 탄막 패턴 변경: {currentBulletPattern}");
+        }
+    }
+
+    #region 다양한 탄막 패턴들
+
+    private IEnumerator StraightBulletAttack()
+    {
+        Vector3 dir = (playerTransform.position - transform.position).normalized;
+
+        for (int i = 0; i < bossBulletCount; i++)
+        {
+            CreateBossBullet(dir, bossBulletSpeed);
+            yield return new WaitForSeconds(0.15f);
+        }
+    }
+
+    private IEnumerator CircularBulletAttack()
+    {
+        float angleStep = 360f / bossBulletCount;
+
+        for (int i = 0; i < bossBulletCount; i++)
+        {
+            float angle = i * angleStep;
+            Vector3 direction = new Vector3(
+                Mathf.Cos(angle * Mathf.Deg2Rad),
+                0,
+                Mathf.Sin(angle * Mathf.Deg2Rad)
+            );
+
+            CreateBossBullet(direction, bossBulletSpeed);
+            yield return new WaitForSeconds(0.1f);
+        }
+    }
+
+    private IEnumerator SpiralBulletAttack()
+    {
+        float totalBullets = bossBulletCount * 1.5f;
+        float angleIncrement = 25f;
+        float currentAngle = 0f;
+
+        for (int i = 0; i < totalBullets; i++)
+        {
+            Vector3 direction = new Vector3(
+                Mathf.Cos(currentAngle * Mathf.Deg2Rad),
+                0,
+                Mathf.Sin(currentAngle * Mathf.Deg2Rad)
+            );
+
+            CreateBossBullet(direction, bossBulletSpeed * 0.8f);
+            currentAngle += angleIncrement;
+            yield return new WaitForSeconds(0.08f);
+        }
+    }
+
+    private IEnumerator FanBulletAttack()
+    {
+        Vector3 playerDir = (playerTransform.position - transform.position).normalized;
+        float fanAngle = 60f; // 부채꼴 각도
+        float angleStep = fanAngle / (bossBulletCount - 1);
+
+        for (int i = 0; i < bossBulletCount; i++)
+        {
+            float angle = -fanAngle * 0.5f + angleStep * i;
+            Quaternion rotation = Quaternion.AngleAxis(angle, Vector3.up);
+            Vector3 direction = rotation * playerDir;
+
+            CreateBossBullet(direction, bossBulletSpeed);
+            yield return new WaitForSeconds(0.1f);
+        }
+    }
+
+    private IEnumerator HomingBulletAttack()
+    {
+        for (int i = 0; i < bossBulletCount * 0.6f; i++)
+        {
+            // 유도탄은 적게 발사하지만 위험
+            Vector3 randomDir = new Vector3(
+                Random.Range(-1f, 1f),
+                0,
+                Random.Range(-1f, 1f)
+            ).normalized;
+
+            CreateHomingBullet(randomDir);
+            yield return new WaitForSeconds(0.3f);
+        }
+    }
+
+    private IEnumerator BurstBulletAttack()
+    {
+        // 3번의 폭발적 발사
+        for (int burst = 0; burst < 3; burst++)
+        {
+            // 각 폭발마다 원형으로 발사
+            float burstCount = bossBulletCount * 0.7f;
+            float angleStep = 360f / burstCount;
+
+            for (int i = 0; i < burstCount; i++)
+            {
+                float angle = i * angleStep + (burst * 15f); // 약간의 회전 추가
+                Vector3 direction = new Vector3(
+                    Mathf.Cos(angle * Mathf.Deg2Rad),
+                    0,
+                    Mathf.Sin(angle * Mathf.Deg2Rad)
+                );
+
+                CreateBossBullet(direction, bossBulletSpeed * 1.2f);
+            }
+
+            yield return new WaitForSeconds(0.8f);
+        }
+    }
+
+    #endregion
+
+    #region 정리 및 오버라이드
+
+    private void CleanupModeAttacks()
+    {
+        if (pullBulletSpawnRoutine != null)
+        {
+            StopCoroutine(pullBulletSpawnRoutine);
+            pullBulletSpawnRoutine = null;
+        }
+
+        activePullBullets.ForEach(bullet => { if (bullet != null) Destroy(bullet); });
+        activePullBullets.Clear();
+
+        if (activeDarkFloorHazard != null)
+        {
+            Destroy(activeDarkFloorHazard);
+            activeDarkFloorHazard = null;
+        }
+    }
+
+    protected override void Die()
+    {
+        // 모든 상태 초기화
+        isCreatingPullBullets = false;
+        isCreatingDarkFloor = false;
+        isShootingBossBullets = false;
+
+        CleanupModeAttacks();
+
+        Debug.Log("어둠의 힘이... 사라진다...");
+        base.Die();
+    }
+
+    protected override int GetExperienceReward()
+    {
+        return 1500; // 최종보스답게 높은 경험치
+    }
+
+    #endregion
+
+    #region 퍼블릭 접근자 및 유틸리티
+
+    public void SetPullBulletSpawnInterval(float interval) => pullBulletSpawnInterval = interval;
+
+    public int GetActivePullBulletCount()
+    {
+        activePullBullets.RemoveAll(bullet => bullet == null);
+        return activePullBullets.Count;
+    }
+
+    public bool IsPerformingSpecialAttack() => IsPerformingAnyAttack();
+
+    #endregion
+
+    #endregion
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Dark.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Dark.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d98bee2fab6588a488101232e070e9b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Light.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Light.cs
@@ -1,0 +1,303 @@
+using UnityEngine;
+using Enemy;
+using System.Collections;
+
+/// <summary>
+/// 최종보스 - 빛 모드 (레일건, 검기, 빛 기둥)
+/// </summary>
+public class Enemy_Final_Boss_Light : Enemy_Base
+{
+    [Header("레일건 빔")]
+    [SerializeField] private GameObject railgunBeamPrefab;
+    [SerializeField] private float railgunDamage = 120f;
+    [SerializeField] private float railgunChargeTime = 2f;
+    [SerializeField] private float railgunCooldown = 4f;
+
+    [Header("검기 공격")]
+    [SerializeField] private GameObject swordBeamPrefab;
+    [SerializeField] private float swordBeamDamage = 80f;
+
+    [Header("빛 기둥")]
+    [SerializeField] private GameObject lightPillarPrefab;
+    [SerializeField] private float lightPillarDamage = 100f;
+    [SerializeField] private float lightPillarInterval = 6f;
+
+    private bool isPerformingAttack = false;
+    private float lastRailgunTime = 0f;
+    private float lastLightPillarTime = 0f;
+
+    // Move 스크립트 호환용 프로퍼티
+    public bool IsPerformingSpecialAttack => isPerformingAttack;
+
+    protected override void Awake()
+    {
+        enemyType = EnemyType.MiddleBoss;
+        elementType = ElementType.Light;
+        primaryDamageType = DamageType.Magical;
+        enemyName = "Light Sovereign";
+
+        base.Awake();
+    }
+
+    protected override void InitializeEnemy()
+    {
+        base.InitializeEnemy();
+        Debug.Log("빛 모드 보스 활성화! 빛의 힘을 사용합니다.");
+
+        StartCoroutine(LightModeAttackRoutine());
+    }
+
+    public void SetHealth(float health)
+    {
+        currentHp = health;
+    }
+
+    protected override void UpdateBehavior()
+    {
+        if (isPerformingAttack) return;
+
+        // 레일건 빔 공격
+        if (Time.time - lastRailgunTime >= railgunCooldown)
+        {
+            StartCoroutine(PerformRailgunBeamAttack());
+            lastRailgunTime = Time.time;
+        }
+
+        // 빛 기둥 공격
+        if (Time.time - lastLightPillarTime >= lightPillarInterval)
+        {
+            StartCoroutine(PerformLightPillarAttack());
+            lastLightPillarTime = Time.time;
+        }
+    }
+
+    private IEnumerator LightModeAttackRoutine()
+    {
+        while (currentHp > 0)
+        {
+            yield return StartCoroutine(PerformSwordBeamAttack());
+            yield return new WaitForSeconds(2f);
+        }
+    }
+
+    private IEnumerator PerformRailgunBeamAttack()
+    {
+        isPerformingAttack = true;
+        Debug.Log("레일건 빔 공격!");
+
+        yield return new WaitForSeconds(railgunChargeTime);
+
+        if (playerTransform != null)
+        {
+            Vector3 direction = (playerTransform.position - transform.position).normalized;
+            Vector3 spawnPosition = transform.position;
+
+            if (railgunBeamPrefab != null)
+            {
+                GameObject beam = Instantiate(railgunBeamPrefab, spawnPosition, Quaternion.LookRotation(direction));
+                Enemy_Final_Boss_RailgunBeam beamScript = beam.GetComponent<Enemy_Final_Boss_RailgunBeam>();
+                if (beamScript != null)
+                {
+                    beamScript.Initialize(railgunDamage, direction, 30f);
+                }
+            }
+            else
+            {
+                CreateTempRailgunBeam(spawnPosition, direction);
+            }
+        }
+
+        isPerformingAttack = false;
+    }
+
+    private void CreateTempRailgunBeam(Vector3 position, Vector3 direction)
+    {
+        GameObject tempBeam = new GameObject("TempRailgunBeam");
+        tempBeam.transform.position = position;
+        tempBeam.transform.rotation = Quaternion.LookRotation(direction);
+
+        Enemy_Final_Boss_RailgunBeam beamScript = tempBeam.AddComponent<Enemy_Final_Boss_RailgunBeam>();
+        beamScript.Initialize(railgunDamage, direction, 30f);
+    }
+
+    private IEnumerator PerformSwordBeamAttack()
+    {
+        isPerformingAttack = true;
+        Debug.Log("검기 공격!");
+
+        for (int i = 0; i < 3; i++)
+        {
+            if (playerTransform != null)
+            {
+                // 플레이어를 향하는 방향 벡터 계산 (Y축 무시)
+                Vector3 direction = playerTransform.position - transform.position;
+                direction.y = 0f;
+                direction.Normalize();
+
+                // 각도 오프셋 (좌우 퍼짐)
+                float angleOffset = (i - 1) * 15f;
+
+                // Y축 기준으로 회전 적용
+                Quaternion yRotation = Quaternion.AngleAxis(angleOffset, Vector3.up);
+                Vector3 finalDirection = yRotation * direction;
+
+                // 검기 방향으로 회전값 생성 (up 방향 고정!)
+                Quaternion rotation = Quaternion.LookRotation(finalDirection, Vector3.up);
+
+                if (swordBeamPrefab != null)
+                {
+                    GameObject swordBeam = Instantiate(swordBeamPrefab, transform.position, rotation);
+                    Enemy_Final_Boss_SwordBeam beamScript = swordBeam.GetComponent<Enemy_Final_Boss_SwordBeam>();
+                    if (beamScript != null)
+                    {
+                        beamScript.Initialize(swordBeamDamage, finalDirection * 15f);
+                    }
+                }
+                else
+                {
+                    // 디버깅용 임시 검기 생성
+                    CreateTempSwordBeam(finalDirection, i);
+                }
+            }
+
+            yield return new WaitForSeconds(0.3f);
+        }
+
+        isPerformingAttack = false;
+    }
+
+
+    private void CreateTempSwordBeam(Vector3 direction, int index)
+    {
+        GameObject swordBeam = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        swordBeam.name = "TempSwordBeam_" + index;
+        swordBeam.transform.position = transform.position;
+        swordBeam.transform.localScale = new Vector3(0.5f, 0.5f, 4f);
+
+        // Y축 고정 회전 적용
+        swordBeam.transform.rotation = Quaternion.LookRotation(direction, Vector3.up);
+
+        Renderer renderer = swordBeam.GetComponent<Renderer>();
+        Material material = new Material(Shader.Find("Standard"));
+        material.color = Color.yellow;
+        material.EnableKeyword("_EMISSION");
+        material.SetColor("_EmissionColor", Color.yellow * 3f);
+        renderer.material = material;
+
+        Rigidbody rb = swordBeam.AddComponent<Rigidbody>();
+        rb.useGravity = false;
+        rb.velocity = direction * 15f;
+
+        Collider collider = swordBeam.GetComponent<Collider>();
+        collider.isTrigger = true;
+
+        Enemy_Temp_Damage_Projectile damageScript = swordBeam.AddComponent<Enemy_Temp_Damage_Projectile>();
+        damageScript.Initialize(swordBeamDamage, "검기");
+
+        Destroy(swordBeam, 3f);
+    }
+
+    private IEnumerator PerformLightPillarAttack()
+    {
+        Debug.Log("빛 기둥 공격!");
+
+        if (playerTransform != null)
+        {
+            Vector3 pillarPosition = playerTransform.position;
+            pillarPosition.y = 0;
+
+            // 경고 표시
+            GameObject warning = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            warning.name = "LightPillarWarning";
+            warning.transform.position = pillarPosition + Vector3.up * 0.1f;
+            warning.transform.localScale = new Vector3(4f, 0.2f, 4f);
+
+            Renderer warningRenderer = warning.GetComponent<Renderer>();
+            Material warningMaterial = new Material(Shader.Find("Standard"));
+            warningMaterial.color = Color.red;
+            warningMaterial.EnableKeyword("_EMISSION");
+            warningMaterial.SetColor("_EmissionColor", Color.red * 3f);
+            warningRenderer.material = warningMaterial;
+
+            StartCoroutine(BlinkWarning(warning));
+
+            yield return new WaitForSeconds(2f);
+
+            Destroy(warning);
+
+            // 실제 빛 기둥 생성
+            if (lightPillarPrefab != null)
+            {
+                GameObject pillar = Instantiate(lightPillarPrefab, pillarPosition, Quaternion.identity);
+                Enemy_Final_Boss_LightPillar pillarScript = pillar.GetComponent<Enemy_Final_Boss_LightPillar>();
+                if (pillarScript != null)
+                {
+                    pillarScript.StartLightPillar(lightPillarDamage, 3f);
+                }
+            }
+            else
+            {
+                CreateTempLightPillar(pillarPosition);
+            }
+        }
+    }
+
+    private void CreateTempLightPillar(Vector3 position)
+    {
+        GameObject pillar = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
+        pillar.name = "TempLightPillar";
+        pillar.transform.position = position + Vector3.up * 10f;
+        pillar.transform.localScale = new Vector3(4f, 10f, 4f);
+
+        Renderer pillarRenderer = pillar.GetComponent<Renderer>();
+        Material pillarMaterial = new Material(Shader.Find("Standard"));
+        pillarMaterial.color = Color.white;
+        pillarMaterial.EnableKeyword("_EMISSION");
+        pillarMaterial.SetColor("_EmissionColor", Color.white * 4f);
+        pillarRenderer.material = pillarMaterial;
+
+        Collider pillarCollider = pillar.GetComponent<Collider>();
+        pillarCollider.isTrigger = true;
+
+        Enemy_Temp_Damage_Projectile damageScript = pillar.AddComponent<Enemy_Temp_Damage_Projectile>();
+        damageScript.Initialize(lightPillarDamage, "빛 기둥", true);
+
+        Destroy(pillar, 5f);
+    }
+
+    private IEnumerator BlinkWarning(GameObject warning)
+    {
+        Renderer renderer = warning.GetComponent<Renderer>();
+        float blinkTime = 0f;
+
+        while (warning != null && blinkTime < 2f)
+        {
+            bool visible = Mathf.Sin(Time.time * 10f) > 0;
+            renderer.enabled = visible;
+
+            blinkTime += Time.deltaTime;
+            yield return null;
+        }
+    }
+
+    protected override void UpdateMovement()
+    {
+        // 보스는 움직이지 않음
+    }
+
+    protected override void PerformAttack()
+    {
+        // 기본 공격은 사용하지 않음
+    }
+
+    protected override void Die()
+    {
+        Debug.Log("빛의 힘이... 사라진다...");
+        base.Die();
+    }
+
+    protected override int GetExperienceReward()
+    {
+        return 1000;
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Light.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Light.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47938bf2ea80d8b42869c27712e02f15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Move.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Move.cs
@@ -1,0 +1,354 @@
+using UnityEngine;
+
+/// <summary>
+/// 최종보스 이동 처리 스크립트 - 중간보스 패턴 적용
+/// 모든 최종보스 모드에서 공통으로 사용 가능
+/// </summary>
+[DisallowMultipleComponent]
+public class Enemy_Final_Boss_Move : MonoBehaviour
+{
+    [Header("이동 설정")]
+    [SerializeField] private float rotationSpeed = 2f; // 회전 속도 (최종보스는 느리게)
+    [SerializeField] private float stoppingDistance = 8f; // 정지 거리 (최종보스는 넓게)
+    [SerializeField] private float circleRadius = 12f; // 원형 이동 반지름
+
+    [Header("최종보스 전용 설정")]
+    [SerializeField] private bool allowMovement = true; // 이동 허용 여부
+    [SerializeField] private float moveSpeedMultiplier = 0.5f; // 이동속도 배율 (최종보스는 느리게)
+
+    private Transform target;
+    private Rigidbody rigid;
+
+    // 최종보스 스크립트들 참조 (다형성 활용)
+    private Enemy_Base bossScript;
+    private Enemy_Final_Boss_Neutral neutralBoss;
+    private Enemy_Final_Boss_Dark darkBoss;
+    // lightBoss 참조 제거 - 기존 파일과 충돌 방지
+
+    // 이동 패턴
+    private Vector3 circleCenter;
+    private float circleAngle = 0f;
+    private bool isCircling = false;
+
+    private void Start()
+    {
+        // 타겟 찾기 (플레이어)
+        target = GameObject.FindGameObjectWithTag("Player")?.transform;
+        if (target == null)
+        {
+            target = GameObject.Find("Player")?.transform;
+        }
+
+        rigid = GetComponent<Rigidbody>();
+        bossScript = GetComponent<Enemy_Base>();
+
+        // Rigidbody가 없으면 경고 메시지
+        if (rigid == null)
+        {
+            Debug.LogWarning($"{gameObject.name}에 Rigidbody 컴포넌트가 필요합니다!");
+            return;
+        }
+
+        // 각 최종보스 타입별 스크립트 찾기
+        neutralBoss = GetComponent<Enemy_Final_Boss_Neutral>();
+        darkBoss = GetComponent<Enemy_Final_Boss_Dark>();
+        // lightBoss 참조 제거 - 기존 파일과 충돌 방지
+
+        if (bossScript == null)
+        {
+            Debug.LogError("Enemy_Base 스크립트를 찾을 수 없습니다!");
+        }
+
+        // Rigidbody 설정
+        if (rigid != null)
+        {
+            rigid.constraints = RigidbodyConstraints.FreezePositionY |
+                               RigidbodyConstraints.FreezeRotationX |
+                               RigidbodyConstraints.FreezeRotationZ;
+            rigid.drag = 8f; // 최종보스는 높은 저항
+            rigid.angularDrag = 8f;
+        }
+
+        // 원형 이동 중심점 설정
+        circleCenter = transform.position;
+    }
+
+    private void FixedUpdate()
+    {
+        // 기본 조건 체크
+        if (bossScript == null || target == null || bossScript.IsDead() || rigid == null)
+        {
+            if (rigid != null) StopMovement();
+            return;
+        }
+
+        // 이동 허용 여부 체크
+        if (!allowMovement)
+        {
+            StopMovement();
+            LookAtTarget();
+            return;
+        }
+
+        // 각 보스 타입별 이동 조건 체크
+        if (ShouldMove())
+        {
+            HandleBossMovement();
+        }
+        else
+        {
+            StopMovement();
+        }
+
+        // 항상 플레이어를 바라보기
+        LookAtTarget();
+    }
+
+    #region 이동 조건 체크
+
+    /// <summary>
+    /// 각 보스 타입별 이동 가능 여부 판단
+    /// </summary>
+    private bool ShouldMove()
+    {
+        // 중립 보스 (오브 관리)
+        if (neutralBoss != null)
+        {
+            return !neutralBoss.IsTransitioning && !neutralBoss.IsSpawningOrbs;
+        }
+
+        // 어둠 보스
+        if (darkBoss != null)
+        {
+            return !darkBoss.IsPerformingSpecialAttack();
+        }
+
+        // 라이트 보스는 기존 파일 사용으로 특별한 제한 없음
+        // 또는 Enemy_Base의 기본 동작 사용
+
+        // 기본적으로 이동 허용
+        return true;
+    }
+
+    #endregion
+
+    #region 보스 이동 패턴
+
+    /// <summary>
+    /// 최종보스 이동 처리 (중간보스보다 더 위엄있게)
+    /// </summary>
+    private void HandleBossMovement()
+    {
+        float distanceToPlayer = Vector3.Distance(transform.position, target.position);
+
+        if (distanceToPlayer > stoppingDistance)
+        {
+            // 플레이어에게 접근 (최종보스는 천천히)
+            MoveTowardsPlayer();
+            isCircling = false;
+        }
+        else
+        {
+            // 가까이 있을 때는 원형 이동
+            CircleAroundPlayer();
+        }
+    }
+
+    /// <summary>
+    /// 플레이어에게 천천히 접근
+    /// </summary>
+    private void MoveTowardsPlayer()
+    {
+        Vector3 direction = (target.position - transform.position).normalized;
+        direction.y = 0; // Y축 이동 제거
+
+        float moveSpeed = bossScript.GetEnemyStats().Get(Enemy.EnemyStatType.MoveSpeed) * moveSpeedMultiplier;
+        Vector3 moveVector = direction * moveSpeed * Time.fixedDeltaTime;
+
+        Vector3 newPosition = rigid.position + moveVector;
+        newPosition.y = rigid.position.y; // Y축 위치 고정
+        rigid.MovePosition(newPosition);
+    }
+
+    /// <summary>
+    /// 플레이어 주변을 위엄있게 원형 이동
+    /// </summary>
+    private void CircleAroundPlayer()
+    {
+        if (!isCircling)
+        {
+            // 원형 이동 시작
+            circleCenter = target.position;
+            Vector3 toTarget = transform.position - circleCenter;
+            toTarget.y = 0;
+            circleAngle = Mathf.Atan2(toTarget.z, toTarget.x);
+            isCircling = true;
+        }
+
+        // 원형 이동 계산
+        float moveSpeed = bossScript.GetEnemyStats().Get(Enemy.EnemyStatType.MoveSpeed) * moveSpeedMultiplier;
+        float angularSpeed = moveSpeed / circleRadius;
+
+        circleAngle += angularSpeed * Time.fixedDeltaTime;
+
+        // 새로운 위치 계산
+        Vector3 offset = new Vector3(
+            Mathf.Cos(circleAngle) * circleRadius,
+            0,
+            Mathf.Sin(circleAngle) * circleRadius
+        );
+
+        Vector3 targetPosition = circleCenter + offset;
+        targetPosition.y = transform.position.y; // Y축 위치 고정
+
+        // 부드럽게 이동
+        Vector3 moveDirection = (targetPosition - rigid.position).normalized;
+        Vector3 moveVector = moveDirection * moveSpeed * Time.fixedDeltaTime;
+
+        rigid.MovePosition(rigid.position + moveVector);
+
+        // 원형 이동 중심점 업데이트 (플레이어가 움직일 경우)
+        Vector3 newCenter = Vector3.Lerp(circleCenter, target.position, Time.fixedDeltaTime * 0.5f);
+        circleCenter = newCenter;
+    }
+
+    #endregion
+
+    #region 회전 처리
+
+    /// <summary>
+    /// 플레이어를 향해 천천히 회전 (최종보스다운 위엄)
+    /// </summary>
+    private void LookAtTarget()
+    {
+        Vector3 direction = (target.position - transform.position).normalized;
+        direction.y = 0; // Y축 회전 제거
+
+        if (direction != Vector3.zero)
+        {
+            Quaternion targetRotation = Quaternion.LookRotation(direction);
+            Vector3 eulerAngles = targetRotation.eulerAngles;
+            eulerAngles.x = 0;
+            eulerAngles.z = 0;
+            targetRotation = Quaternion.Euler(eulerAngles);
+
+            transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, rotationSpeed * Time.fixedDeltaTime);
+        }
+    }
+
+    #endregion
+
+    #region 이동 제어
+
+    /// <summary>
+    /// 이동 정지
+    /// </summary>
+    private void StopMovement()
+    {
+        if (rigid != null)
+        {
+            Vector3 vel = rigid.velocity;
+            vel.x = 0;
+            vel.z = 0;
+            rigid.velocity = vel;
+        }
+
+        isCircling = false;
+    }
+
+    /// <summary>
+    /// 특정 위치로 강제 이동 (특별한 경우에 사용)
+    /// </summary>
+    public void MoveTo(Vector3 targetPosition)
+    {
+        if (!allowMovement) return;
+
+        StopMovement();
+        StartCoroutine(MoveToPositionCoroutine(targetPosition));
+    }
+
+    private System.Collections.IEnumerator MoveToPositionCoroutine(Vector3 targetPosition)
+    {
+        Vector3 startPos = transform.position;
+        targetPosition.y = startPos.y; // Y축 위치 고정
+        float duration = 2f;
+        float elapsed = 0f;
+
+        while (elapsed < duration)
+        {
+            elapsed += Time.deltaTime;
+            float t = elapsed / duration;
+
+            Vector3 currentPos = Vector3.Lerp(startPos, targetPosition, t);
+            transform.position = currentPos;
+
+            yield return null;
+        }
+    }
+
+    public void StopMove()
+    {
+        StopMovement();
+    }
+
+    #endregion
+
+    #region 설정 메서드
+
+    /// <summary>
+    /// 이동 허용/금지 설정
+    /// </summary>
+    public void SetMovementEnabled(bool enabled)
+    {
+        allowMovement = enabled;
+        if (!enabled)
+        {
+            StopMovement();
+        }
+    }
+
+    /// <summary>
+    /// 이동속도 배율 설정
+    /// </summary>
+    public void SetMoveSpeedMultiplier(float multiplier)
+    {
+        moveSpeedMultiplier = Mathf.Clamp(multiplier, 0.1f, 2f);
+    }
+
+    #endregion
+
+    #region 디버그
+
+    private void OnDrawGizmos()
+    {
+        if (target != null)
+        {
+            // 플레이어와의 거리 시각화
+            Gizmos.color = Color.red;
+            Gizmos.DrawLine(transform.position, target.position);
+
+            // 정지 거리 시각화
+            Gizmos.color = Color.yellow;
+            Gizmos.DrawWireSphere(transform.position, stoppingDistance);
+
+            // 원형 이동 반지름 시각화
+            if (isCircling)
+            {
+                Gizmos.color = Color.cyan;
+                Gizmos.DrawWireSphere(circleCenter, circleRadius);
+            }
+        }
+    }
+
+    private void OnDrawGizmosSelected()
+    {
+        // 이동 영역 표시
+        Gizmos.color = Color.green;
+        Gizmos.DrawWireSphere(transform.position, circleRadius);
+
+        Gizmos.color = Color.blue;
+        Gizmos.DrawWireSphere(transform.position, stoppingDistance);
+    }
+
+    #endregion
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Move.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Move.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ecd23123201d704ebe5fcc7dc1dcc61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Neutral.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Neutral.cs
@@ -1,0 +1,446 @@
+using UnityEngine;
+using Enemy;
+using System.Collections;
+
+/// <summary>
+/// 최종보스 - 중립 모드 (오브 관리만) - 중간보스 패턴 적용
+/// </summary>
+[DisallowMultipleComponent]
+public class Enemy_Final_Boss_Neutral : Enemy_Base
+{
+    [Header("오브 프리팹")]
+    [SerializeField] private GameObject lightOrbPrefab;
+    [SerializeField] private GameObject darkOrbPrefab;
+
+    [Header("오브 스폰 설정")]
+    [SerializeField] private Vector3[] orbSpawnPositions;
+    [SerializeField] private float orbSpawnDelay = 1f;
+    [SerializeField] private bool spawnOrbsOnStart = true;
+
+    [Header("모드 전환")]
+    [SerializeField] private GameObject lightModeBoss; // 빛 모드 보스 오브젝트
+    [SerializeField] private GameObject darkModeBoss;  // 어둠 모드 보스 오브젝트
+
+    [Header("보스 설정 (오브 난이도용)")]
+    [SerializeField] private float orbHealthMultiplier = 1f;
+    [SerializeField] private float orbSpeedMultiplier = 1f;
+
+    [Header("회전 설정")]
+    [SerializeField] private float rotationSpeed = 10f;
+
+    // 오브 관리
+    private GameObject lightOrb;
+    private GameObject darkOrb;
+    private bool isTransitioning = false;
+
+    // 상태 플래그
+    private bool isSpawningOrbs = false;
+
+    // 쿨다운 관리
+    private float orbRespawnCooldown = 5f;
+    private float lastOrbCheckTime = 0f;
+
+    // 공개 프로퍼티 (Move 스크립트에서 참조 가능)
+    public bool IsTransitioning => isTransitioning;
+    public bool IsSpawningOrbs => isSpawningOrbs;
+
+    protected override void Awake()
+    {
+        enemyType = EnemyType.FinalBoss;
+        elementType = ElementType.Neutral;
+        primaryDamageType = DamageType.Magical;
+        enemyName = "Dual Sphere Sovereign";
+
+        base.Awake();
+    }
+
+    protected override void InitializeEnemy()
+    {
+        base.InitializeEnemy();
+
+        // 기본 오브 위치 설정
+        SetupOrbSpawnPositions();
+
+        if (spawnOrbsOnStart)
+        {
+            StartCoroutine(SpawnOrbsWithDelay());
+        }
+
+        Debug.Log("중립 모드 보스 등장! 구체들만 공격합니다.");
+    }
+
+    private void SetupOrbSpawnPositions()
+    {
+        if (orbSpawnPositions == null || orbSpawnPositions.Length == 0)
+        {
+            orbSpawnPositions = new Vector3[]
+            {
+                transform.position + Vector3.left * 8f + Vector3.up * 3f,   // 빛 구체
+                transform.position + Vector3.right * 8f + Vector3.up * 2f   // 어둠 구체
+            };
+        }
+    }
+
+    protected override void UpdateBehavior()
+    {
+        // 전환 중이면 다른 행동 중지
+        if (isTransitioning) return;
+
+        // 중립 모드에서는 보스가 직접 공격하지 않음
+        // 구체들만 공격
+
+        // 보스 본체는 천천히 회전만
+        transform.Rotate(Vector3.up, rotationSpeed * Time.deltaTime);
+
+        // 주기적으로 오브 상태 체크
+        if (Time.time - lastOrbCheckTime >= orbRespawnCooldown)
+        {
+            CheckAndRespawnOrbs();
+            lastOrbCheckTime = Time.time;
+        }
+    }
+
+    protected override void UpdateMovement()
+    {
+        // 보스는 움직이지 않음 (고정)
+    }
+
+    protected override void PerformAttack()
+    {
+        // 보스는 직접 공격하지 않음
+    }
+
+    #region 오브 생성 및 관리
+
+    private IEnumerator SpawnOrbsWithDelay()
+    {
+        isSpawningOrbs = true;
+
+        // 빛 구체 먼저 생성
+        yield return new WaitForSeconds(orbSpawnDelay);
+        SpawnLightOrb();
+
+        // 어둠 구체 생성
+        yield return new WaitForSeconds(orbSpawnDelay);
+        SpawnDarkOrb();
+
+        Debug.Log("모든 오브 생성 완료!");
+        isSpawningOrbs = false;
+    }
+
+    private bool CanSpawnOrb()
+    {
+        return !isTransitioning && !isSpawningOrbs;
+    }
+
+    public void SpawnLightOrb()
+    {
+        if (lightOrb != null) return; // 이미 존재하면 생성하지 않음
+
+        Vector3 spawnPos = orbSpawnPositions.Length > 0 ? orbSpawnPositions[0] : transform.position + Vector3.left * 8f;
+
+        if (lightOrbPrefab != null)
+        {
+            lightOrb = Instantiate(lightOrbPrefab, spawnPos, Quaternion.identity);
+            Enemy_Final_Boss_LightOrb lightOrbScript = lightOrb.GetComponent<Enemy_Final_Boss_LightOrb>();
+
+            if (lightOrbScript != null)
+            {
+                lightOrbScript.Initialize(this);
+
+                // 난이도에 따른 설정 조정
+                if (orbHealthMultiplier != 1f)
+                    lightOrbScript.SetHealth(100f * orbHealthMultiplier);
+                if (orbSpeedMultiplier != 1f)
+                    lightOrbScript.SetMoveSpeed(3f * orbSpeedMultiplier);
+            }
+
+            Debug.Log("빛 구체 생성됨!");
+        }
+        else
+        {
+            CreateTempLightOrb(spawnPos);
+        }
+    }
+
+    public void SpawnDarkOrb()
+    {
+        if (darkOrb != null) return; // 이미 존재하면 생성하지 않음
+
+        Vector3 spawnPos = orbSpawnPositions.Length > 1 ? orbSpawnPositions[1] : transform.position + Vector3.right * 8f;
+
+        if (darkOrbPrefab != null)
+        {
+            darkOrb = Instantiate(darkOrbPrefab, spawnPos, Quaternion.identity);
+            Enemy_Final_Boss_DarkOrb darkOrbScript = darkOrb.GetComponent<Enemy_Final_Boss_DarkOrb>();
+
+            if (darkOrbScript != null)
+            {
+                darkOrbScript.Initialize(this);
+
+                // 난이도에 따른 설정 조정
+                if (orbHealthMultiplier != 1f)
+                    darkOrbScript.SetHealth(100f * orbHealthMultiplier);
+                if (orbSpeedMultiplier != 1f)
+                    darkOrbScript.SetMoveSpeed(3f * orbSpeedMultiplier);
+            }
+
+            Debug.Log("어둠 구체 생성됨!");
+        }
+        else
+        {
+            CreateTempDarkOrb(spawnPos);
+        }
+    }
+
+    private void CreateTempLightOrb(Vector3 position)
+    {
+        lightOrb = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        lightOrb.name = "TempLightOrb";
+        lightOrb.transform.position = position;
+        lightOrb.transform.localScale = Vector3.one * 2f;
+
+        Renderer renderer = lightOrb.GetComponent<Renderer>();
+        Material material = new Material(Shader.Find("Standard"));
+        material.color = Color.white;
+        material.EnableKeyword("_EMISSION");
+        material.SetColor("_EmissionColor", Color.white * 2f);
+        renderer.material = material;
+
+        Enemy_Temp_Orb_Health healthScript = lightOrb.AddComponent<Enemy_Temp_Orb_Health>();
+        healthScript.Initialize(this, 100f * orbHealthMultiplier, true);
+    }
+
+    private void CreateTempDarkOrb(Vector3 position)
+    {
+        darkOrb = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        darkOrb.name = "TempDarkOrb";
+        darkOrb.transform.position = position;
+        darkOrb.transform.localScale = Vector3.one * 2f;
+
+        Renderer renderer = darkOrb.GetComponent<Renderer>();
+        Material material = new Material(Shader.Find("Standard"));
+        material.color = Color.red;
+        material.EnableKeyword("_EMISSION");
+        material.SetColor("_EmissionColor", Color.red * 2f);
+        renderer.material = material;
+
+        Enemy_Temp_Orb_Health healthScript = darkOrb.AddComponent<Enemy_Temp_Orb_Health>();
+        healthScript.Initialize(this, 100f * orbHealthMultiplier, false);
+    }
+
+    private void CheckAndRespawnOrbs()
+    {
+        // 오브들이 모두 파괴되었다면 재생성 (안전장치)
+        if (lightOrb == null && darkOrb == null && !isTransitioning)
+        {
+            Debug.Log("모든 오브가 파괴됨! 재생성합니다.");
+            StartCoroutine(SpawnOrbsWithDelay());
+        }
+    }
+
+    #endregion
+
+    #region 오브 파괴 콜백
+
+    public void OnLightOrbDestroyed()
+    {
+        if (isTransitioning) return;
+
+        Debug.Log("빛 구체 파괴! 어둠 모드로 전환!");
+        lightOrb = null;
+        SwitchToDarkMode();
+    }
+
+    public void OnDarkOrbDestroyed()
+    {
+        if (isTransitioning) return;
+
+        Debug.Log("어둠 구체 파괴! 빛 모드로 전환!");
+        darkOrb = null;
+        SwitchToLightMode();
+    }
+
+    #endregion
+
+    #region 모드 전환
+
+    private void SwitchToLightMode()
+    {
+        if (lightModeBoss == null || isTransitioning) return;
+
+        isTransitioning = true;
+        StartCoroutine(TransitionToMode(lightModeBoss, true));
+    }
+
+    private void SwitchToDarkMode()
+    {
+        if (darkModeBoss == null || isTransitioning) return;
+
+        isTransitioning = true;
+        StartCoroutine(TransitionToMode(darkModeBoss, false));
+    }
+
+    private IEnumerator TransitionToMode(GameObject targetBoss, bool isLightMode)
+    {
+        Debug.Log($"{(isLightMode ? "빛" : "어둠")} 모드로 전환 중...");
+
+        // 전환 이벤트 시간
+        yield return new WaitForSeconds(1f);
+
+        // 새로운 보스 생성
+        GameObject newBoss = Instantiate(targetBoss, transform.position, transform.rotation);
+
+        // 체력 전달
+        if (isLightMode)
+        {
+            Enemy_Final_Boss_Light lightBoss = newBoss.GetComponent<Enemy_Final_Boss_Light>();
+            if (lightBoss != null)
+            {
+                lightBoss.SetHealth(currentHp);
+            }
+        }
+        else
+        {
+            Enemy_Final_Boss_Dark darkBoss = newBoss.GetComponent<Enemy_Final_Boss_Dark>();
+            if (darkBoss != null)
+            {
+                darkBoss.SetHealth(currentHp);
+            }
+        }
+
+        // 남은 구체 정리
+        CleanupOrbs();
+
+        // 자신 제거
+        Destroy(gameObject);
+    }
+
+    #endregion
+
+    #region 정리 및 유틸리티
+
+    private void CleanupOrbs()
+    {
+        if (lightOrb != null)
+        {
+            Destroy(lightOrb);
+            lightOrb = null;
+        }
+        if (darkOrb != null)
+        {
+            Destroy(darkOrb);
+            darkOrb = null;
+        }
+    }
+
+    protected override void Die()
+    {
+        CleanupOrbs();
+        base.Die();
+    }
+
+    protected override int GetExperienceReward()
+    {
+        return 1500; // 최종보스답게 높은 경험치
+    }
+
+    #endregion
+
+    #region 런타임에서 오브 설정 변경 가능
+
+    public void SetOrbDifficulty(float healthMultiplier, float speedMultiplier)
+    {
+        orbHealthMultiplier = healthMultiplier;
+        orbSpeedMultiplier = speedMultiplier;
+
+        // 기존 오브들에도 적용
+        if (lightOrb != null)
+        {
+            Enemy_Final_Boss_LightOrb lightScript = lightOrb.GetComponent<Enemy_Final_Boss_LightOrb>();
+            if (lightScript != null)
+            {
+                lightScript.SetHealth(100f * healthMultiplier);
+                lightScript.SetMoveSpeed(3f * speedMultiplier);
+            }
+        }
+
+        if (darkOrb != null)
+        {
+            Enemy_Final_Boss_DarkOrb darkScript = darkOrb.GetComponent<Enemy_Final_Boss_DarkOrb>();
+            if (darkScript != null)
+            {
+                darkScript.SetHealth(100f * healthMultiplier);
+                darkScript.SetMoveSpeed(3f * speedMultiplier);
+            }
+        }
+    }
+
+    // 수동으로 오브 재생성
+    public void RespawnOrbs()
+    {
+        CleanupOrbs();
+        StartCoroutine(SpawnOrbsWithDelay());
+    }
+
+    // 특정 오브만 재생성
+    public void RespawnLightOrb()
+    {
+        if (lightOrb != null) Destroy(lightOrb);
+        SpawnLightOrb();
+    }
+
+    public void RespawnDarkOrb()
+    {
+        if (darkOrb != null) Destroy(darkOrb);
+        SpawnDarkOrb();
+    }
+
+    #endregion
+
+    #region 디버그용 메서드들
+
+    [System.Serializable]
+    public class OrbStatus
+    {
+        public bool lightOrbActive;
+        public bool darkOrbActive;
+        public Vector3 lightOrbPosition;
+        public Vector3 darkOrbPosition;
+    }
+
+    public OrbStatus GetOrbStatus()
+    {
+        return new OrbStatus
+        {
+            lightOrbActive = lightOrb != null,
+            darkOrbActive = darkOrb != null,
+            lightOrbPosition = lightOrb != null ? lightOrb.transform.position : Vector3.zero,
+            darkOrbPosition = darkOrb != null ? darkOrb.transform.position : Vector3.zero
+        };
+    }
+
+    public bool IsPerformingSpecialAction() => isTransitioning || isSpawningOrbs;
+
+    #endregion
+
+    #region 에디터에서 확인용
+
+    private void OnDrawGizmosSelected()
+    {
+        if (orbSpawnPositions != null)
+        {
+            Gizmos.color = Color.white;
+            for (int i = 0; i < orbSpawnPositions.Length; i++)
+            {
+                Vector3 worldPos = Application.isPlaying ? orbSpawnPositions[i] : transform.position + orbSpawnPositions[i];
+                Gizmos.DrawWireSphere(worldPos, 1f);
+
+                if (i == 0) Gizmos.color = Color.cyan;    // 빛 구체 위치
+                else if (i == 1) Gizmos.color = Color.magenta; // 어둠 구체 위치
+            }
+        }
+    }
+
+    #endregion
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Neutral.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Final_Boss_Neutral.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5bc6c6207e08a7b41bdc8c9712f22ebf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss.cs
@@ -1,0 +1,512 @@
+using UnityEngine;
+using Enemy;
+using System.Collections;
+using System.Collections.Generic;
+
+/// <summary>
+/// 중간보스 몬스터 
+/// </summary>
+[DisallowMultipleComponent]
+public class Enemy_Middle_Boss : Enemy_Base
+{
+    [Header("그랩 공격 설정")]
+    [SerializeField] private float grabRange = 12f; // 그랩 투사체 발사 거리
+    [SerializeField] private float grabDamage = 60f; // 그랩 데미지
+    [SerializeField] private float grabCooldown = 6f; // 그랩 쿨다운
+    [SerializeField] private float grabDuration = 1.5f; // 그랩 지속시간
+    [SerializeField] private float pullForce = 8f; // 끌어당기는 힘
+    [SerializeField] private float grabProjectileSpeed = 15f; // 그랩 투사체 속도
+    [SerializeField] private Transform grabFirePoint; // 그랩 투사체 발사점
+
+    [Header("총알 공격 설정")]
+    [SerializeField] private GameObject bulletPrefab; // 총알 프리팹
+    [SerializeField] private Transform firePoint; // 총알 발사점
+    [SerializeField] private float bulletSpeed = 10f; // 총알 속도
+    [SerializeField] private int bulletCount = 6; // 총알 개수 (중간보스용으로 적게)
+    [SerializeField] private float bulletCooldown = 4f; // 총알 쿨다운
+    [SerializeField] private float bulletRange = 8f; // 총알 사용 거리
+
+    [Header("장판 공격 설정")]
+    [SerializeField] private GameObject floorHazardPrefab; // 장판 프리팹
+    [SerializeField] private float floorHazardDamage = 40f; // 장판 데미지
+    [SerializeField] private float floorHazardDuration = 4f; // 장판 지속시간
+    [SerializeField] private float floorHazardCooldown = 8f; // 장판 쿨다운
+    [SerializeField] private float floorHazardRadius = 3f; // 장판 반지름
+    [SerializeField] private int maxFloorHazards = 6; // 최대 동시 장판 개수
+    [SerializeField] private float floorHazardRange = 15f; // 장판 생성 가능 거리
+    [SerializeField] private int hazardsPerCast = 3; // 한 번에 생성할 장판 개수
+    [SerializeField] private float minDistanceFromPlayer = 2f; // 플레이어로부터 최소 거리
+    [SerializeField] private float minDistanceBetweenHazards = 4f; // 장판 간 최소 거리
+
+    [Header("이펙트 및 프리팹")]
+    [SerializeField] private GameObject grabProjectilePrefab; // 그랩 투사체 프리팹
+
+    // 보스 상태
+    private bool isGrabbing = false; // 투사체 발사 중
+    private bool isShooting = false; // 총알 발사 중
+    private bool isCreatingFloorHazard = false; // 장판 생성 중
+
+    // 공격 타이밍
+    private float lastGrabTime;
+    private float lastBulletTime;
+    private float lastFloorHazardTime;
+
+    // 현재 그랩된 플레이어 정보
+    private Transform grabbedPlayer = null;
+    private bool isPlayerBeingPulled = false; // 플레이어 끌어당기는 중
+    private float pullStartTime;
+    private float currentPullDuration;
+
+    // 현재 활성화된 장판 개수 추적
+    private int currentFloorHazardCount = 0;
+
+    // Move 스크립트에서 참조할 수 있는 프로퍼티들
+    public bool IsGrabbing => isGrabbing; // 투사체 발사 중
+    public bool IsShooting => isShooting;
+    public bool IsPlayerBeingPulled => isPlayerBeingPulled; // 플레이어 끌어당기는 중
+    public bool IsCreatingFloorHazard => isCreatingFloorHazard; // 장판 생성 중
+
+    protected override void Awake()
+    {
+        // 중간보스 기본 설정
+        enemyType = EnemyType.MiddleBoss;
+        elementType = ElementType.Dark;
+        primaryDamageType = DamageType.Magical;
+        enemyName = "Shadow Guardian";
+
+        base.Awake();
+    }
+
+    protected override void InitializeEnemy()
+    {
+        base.InitializeEnemy();
+
+        // 총알 발사점이 없으면 자신의 위치 사용
+        if (firePoint == null)
+            firePoint = transform;
+
+        // 그랩 발사점이 없으면 자신의 위치 사용
+        if (grabFirePoint == null)
+            grabFirePoint = transform;
+
+        Debug.Log($"중간보스 {enemyName} 등장! HP: {currentHp}");
+    }
+
+    protected override void UpdateBehavior()
+    {
+        // 플레이어를 끌어당기는 중이면 다른 행동 제한
+        if (isPlayerBeingPulled)
+        {
+            UpdatePullBehavior();
+            return;
+        }
+
+        // 총알 발사 중이면 이동 제한
+        if (isShooting || isCreatingFloorHazard)
+        {
+            return;
+        }
+
+        if (playerTransform == null) return;
+
+        float distanceToPlayer = GetDistanceToPlayer();
+
+        // 거리에 따른 공격 패턴 선택 (중간보스는 단순)
+        if (distanceToPlayer >= grabRange * 0.8f && CanUseGrab())
+        {
+            // 원거리에서 그랩 투사체 발사
+            StartCoroutine(PerformGrabAttack());
+        }
+        else if (distanceToPlayer <= floorHazardRange && CanUseFloorHazard())
+        {
+            // 장판 공격 우선 사용 (더 위험한 공격)
+            StartCoroutine(PerformFloorHazardAttack());
+        }
+        else if (distanceToPlayer <= bulletRange && CanUseBullets())
+        {
+            // 근거리에서 총알 공격
+            StartCoroutine(PerformBulletAttack());
+        }
+    }
+
+    protected override void UpdateMovement()
+    {
+        // 이동은 Enemy_Boss_Move에서 처리
+    }
+
+    protected override void PerformAttack()
+    {
+        // 기본 공격은 사용하지 않음
+    }
+
+    #region 그랩 투사체 공격
+
+    private bool CanUseGrab()
+    {
+        return Time.time - lastGrabTime >= grabCooldown && !isGrabbing && !isShooting && !isPlayerBeingPulled && !isCreatingFloorHazard;
+    }
+
+    private IEnumerator PerformGrabAttack()
+    {
+        isGrabbing = true;
+        lastGrabTime = Time.time;
+
+        // 그랩 투사체 발사 준비 (짧은 준비 시간)
+        yield return new WaitForSeconds(0.3f);
+
+        // 플레이어 방향으로 그랩 투사체 발사
+        if (playerTransform != null)
+        {
+            FireGrabProjectile();
+        }
+
+        yield return new WaitForSeconds(0.2f);
+        isGrabbing = false;
+    }
+
+    private void FireGrabProjectile()
+    {
+        if (grabProjectilePrefab == null)
+        {
+            return;
+        }
+
+        if (playerTransform == null) return;
+
+        // 플레이어 방향으로 투사체 발사
+        Vector3 direction = (playerTransform.position - grabFirePoint.position).normalized;
+        direction.y = 0; // Y축 무시
+
+        // 그랩 투사체 생성
+        GameObject grabProjectile = Instantiate(grabProjectilePrefab, grabFirePoint.position, Quaternion.LookRotation(direction));
+
+        // 투사체에 속도 적용
+        Rigidbody projectileRb = grabProjectile.GetComponent<Rigidbody>();
+        if (projectileRb != null)
+        {
+            projectileRb.velocity = direction * grabProjectileSpeed;
+        }
+
+        // 투사체 초기화
+        Enemy_Middle_Boss_Grab grabScript = grabProjectile.GetComponent<Enemy_Middle_Boss_Grab>();
+        if (grabScript != null)
+        {
+            grabScript.Initialize(this, pullForce, grabDuration, grabDamage);
+        }
+
+    }
+
+    /// <summary>
+    /// 그랩 투사체가 플레이어에게 맞았을 때 호출되는 콜백
+    /// </summary>
+    public void OnGrabProjectileHit(Transform player, float force, float duration)
+    {
+        if (isPlayerBeingPulled) return; // 이미 끌어당기고 있으면 무시
+
+        grabbedPlayer = player;
+        isPlayerBeingPulled = true;
+        pullStartTime = Time.time;
+        currentPullDuration = duration;
+
+
+        // 끌어당기기 코루틴 시작
+        StartCoroutine(PullPlayerCoroutine(force, duration));
+    }
+
+    private IEnumerator PullPlayerCoroutine(float force, float duration)
+    {
+        float elapsed = 0f;
+
+        while (elapsed < duration && isPlayerBeingPulled && grabbedPlayer != null)
+        {
+            // 보스 쪽으로 플레이어를 끌어당기기 (Y축 고정)
+            Vector3 directionToBoss = (transform.position - grabbedPlayer.position).normalized;
+            directionToBoss.y = 0; // Y축 방향 제거
+
+            Vector3 pullPosition = grabbedPlayer.position + directionToBoss * force * Time.deltaTime;
+            pullPosition.y = grabbedPlayer.position.y; // Y축 위치 고정
+
+            // 보스에게 너무 가까이 가지 않도록 제한 (최소 2m 거리 유지)
+            float distanceToBoss = Vector3.Distance(new Vector3(pullPosition.x, 0, pullPosition.z),
+                                                  new Vector3(transform.position.x, 0, transform.position.z));
+            if (distanceToBoss > 2f)
+            {
+                grabbedPlayer.position = pullPosition;
+            }
+
+            // 0.5초마다 추가 데미지
+            if (elapsed % 0.5f < Time.deltaTime && elapsed > 0.1f) // 첫 데미지는 투사체에서 주니까 제외
+            {
+                DealDamageToPlayer(DamageType.Magical);
+            }
+
+            elapsed += Time.deltaTime;
+            yield return null;
+        }
+
+        // 끌어당기기 종료
+        isPlayerBeingPulled = false;
+        grabbedPlayer = null;
+    }
+
+    private void UpdatePullBehavior()
+    {
+        // 끌어당기기 중에는 움직이지 않음
+        if (isPlayerBeingPulled && Time.time - pullStartTime >= currentPullDuration)
+        {
+            isPlayerBeingPulled = false;
+            grabbedPlayer = null;
+        }
+    }
+
+    #endregion
+
+    #region 총알 공격
+
+    private bool CanUseBullets()
+    {
+        return Time.time - lastBulletTime >= bulletCooldown && !isGrabbing && !isShooting && !isPlayerBeingPulled && !isCreatingFloorHazard;
+    }
+
+    private IEnumerator PerformBulletAttack()
+    {
+        isShooting = true;
+        lastBulletTime = Time.time;
+
+        // 시전 시간
+        yield return new WaitForSeconds(0.5f);
+
+        // 총알 발사
+        FireBulletsInCircle();
+
+        yield return new WaitForSeconds(0.5f);
+        isShooting = false;
+    }
+
+    private void FireBulletsInCircle()
+    {
+        if (bulletPrefab == null)
+        {
+            return;
+        }
+
+        float angleStep = 360f / bulletCount;
+
+        for (int i = 0; i < bulletCount; i++)
+        {
+            float angle = i * angleStep;
+            Vector3 direction = new Vector3(
+                Mathf.Cos(angle * Mathf.Deg2Rad),
+                0,
+                Mathf.Sin(angle * Mathf.Deg2Rad)
+            );
+
+            // 총알 생성
+            GameObject bullet = Instantiate(bulletPrefab, firePoint.position, Quaternion.LookRotation(direction));
+
+            // 총알에 속도 적용
+            Rigidbody bulletRb = bullet.GetComponent<Rigidbody>();
+            if (bulletRb != null)
+            {
+                bulletRb.velocity = direction * bulletSpeed;
+            }
+
+            // 총알 데미지 설정
+            Enemy_Middle_Boss_Bullet bulletScript = bullet.GetComponent<Enemy_Middle_Boss_Bullet>();
+            if (bulletScript != null)
+            {
+                float bulletDamage = enemyStats.Get(EnemyStatType.MagicalDamage) * 0.4f;
+                bulletScript.Initialize(bulletDamage, DamageType.Magical);
+            }
+
+            // 5초 후 총알 삭제
+            Destroy(bullet, 5f);
+        }
+
+    }
+
+    #endregion
+
+    #region 장판 공격
+
+    private bool CanUseFloorHazard()
+    {
+        return Time.time - lastFloorHazardTime >= floorHazardCooldown &&
+               !isGrabbing && !isShooting && !isPlayerBeingPulled && !isCreatingFloorHazard &&
+               currentFloorHazardCount + hazardsPerCast <= maxFloorHazards; // 한 번에 생성할 개수를 고려
+    }
+
+    private IEnumerator PerformFloorHazardAttack()
+    {
+        isCreatingFloorHazard = true;
+        lastFloorHazardTime = Time.time;
+
+        // 장판 생성 시전 시간 (여러 개 생성하므로 조금 더 길게)
+        yield return new WaitForSeconds(1.2f);
+
+        // 플레이어 위치 주변에 여러 장판 랜덤 생성
+        if (playerTransform != null)
+        {
+            CreateFloorHazard();
+        }
+
+        yield return new WaitForSeconds(0.3f);
+        isCreatingFloorHazard = false;
+    }
+
+    private void CreateFloorHazard()
+    {
+        if (floorHazardPrefab == null || playerTransform == null)
+        {
+            return;
+        }
+
+        // 현재 생성 가능한 장판 개수 계산
+        int hazardsToCreate = Mathf.Min(hazardsPerCast, maxFloorHazards - currentFloorHazardCount);
+
+        if (hazardsToCreate <= 0) return;
+
+        List<Vector3> createdPositions = new List<Vector3>();
+
+        for (int i = 0; i < hazardsToCreate; i++)
+        {
+            Vector3 hazardPosition = FindValidHazardPosition(createdPositions);
+
+            if (hazardPosition != Vector3.zero) // 유효한 위치를 찾았다면
+            {
+                // 장판 생성
+                GameObject floorHazard = Instantiate(floorHazardPrefab, hazardPosition, Quaternion.identity);
+
+                // 장판 초기화
+                Enemy_Middle_Boss_FloorHazard hazardScript = floorHazard.GetComponent<Enemy_Middle_Boss_FloorHazard>();
+                if (hazardScript != null)
+                {
+                    hazardScript.Initialize(floorHazardDamage, floorHazardDuration, floorHazardRadius, this);
+                }
+
+                // 현재 장판 개수 증가
+                currentFloorHazardCount++;
+
+                // 생성된 위치 기록
+                createdPositions.Add(hazardPosition);
+
+                // 지속시간 후 자동 삭제
+                StartCoroutine(DestroyFloorHazardAfterDuration(floorHazard, floorHazardDuration));
+            }
+        }
+    }
+
+    /// <summary>
+    /// 유효한 장판 생성 위치 찾기
+    /// </summary>
+    private Vector3 FindValidHazardPosition(List<Vector3> existingPositions)
+    {
+        const int maxAttempts = 20; // 최대 시도 횟수
+
+        for (int attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            // 플레이어 중심으로 원형 범위 내에서 랜덤 위치 생성
+            Vector2 randomCircle = Random.insideUnitCircle * floorHazardRange;
+            Vector3 candidatePosition = playerTransform.position + new Vector3(randomCircle.x, 0, randomCircle.y);
+            candidatePosition.y = 0; // Y축은 지면에 고정
+
+            // 유효성 검사
+            if (IsValidHazardPosition(candidatePosition, existingPositions))
+            {
+                return candidatePosition;
+            }
+        }
+
+        // 유효한 위치를 찾지 못한 경우
+        Debug.LogWarning("유효한 장판 위치를 찾지 못했습니다.");
+        return Vector3.zero;
+    }
+
+    /// <summary>
+    /// 장판 위치가 유효한지 검사
+    /// </summary>
+    private bool IsValidHazardPosition(Vector3 position, List<Vector3> existingPositions)
+    {
+        // 1. 플레이어로부터 최소 거리 체크
+        float distanceToPlayer = Vector3.Distance(position, playerTransform.position);
+        if (distanceToPlayer < minDistanceFromPlayer)
+        {
+            return false;
+        }
+
+        // 2. 보스로부터 너무 가깝지 않게 (최소 1m)
+        float distanceToBoss = Vector3.Distance(position, transform.position);
+        if (distanceToBoss < 1f)
+        {
+            return false;
+        }
+
+        // 3. 이미 생성된 장판들과의 거리 체크
+        foreach (Vector3 existingPos in existingPositions)
+        {
+            float distance = Vector3.Distance(position, existingPos);
+            if (distance < minDistanceBetweenHazards)
+            {
+                return false;
+            }
+        }
+
+        // 4. 맵 경계 체크 (옵션: 필요시 활성화)
+        // if (!IsWithinMapBounds(position))
+        // {
+        //     return false;
+        // }
+
+        return true;
+    }
+
+    private IEnumerator DestroyFloorHazardAfterDuration(GameObject hazard, float duration)
+    {
+        yield return new WaitForSeconds(duration);
+
+        if (hazard != null)
+        {
+            currentFloorHazardCount--;
+            Destroy(hazard);
+        }
+    }
+
+    /// <summary>
+    /// 장판이 파괴될 때 호출되는 콜백 (외부에서 호출 가능)
+    /// </summary>
+    public void OnFloorHazardDestroyed()
+    {
+        currentFloorHazardCount = Mathf.Max(0, currentFloorHazardCount - 1);
+    }
+
+    #endregion
+
+    #region 오버라이드 메서드
+
+    protected override void Die()
+    {
+
+        // 모든 상태 초기화
+        isGrabbing = false;
+        isShooting = false;
+        isPlayerBeingPulled = false;
+        isCreatingFloorHazard = false;
+        grabbedPlayer = null;
+        currentFloorHazardCount = 0;
+
+        base.Die();
+    }
+
+    protected override int GetExperienceReward()
+    {
+        return 300; // 중간보스니까 경험치도 적당히
+    }
+
+    #endregion
+
+    #region 퍼블릭 접근자
+
+    public bool IsPerformingSpecialAttack() => isGrabbing || isShooting || isPlayerBeingPulled || isCreatingFloorHazard;
+
+    #endregion
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 935b6e3b031394e428e8bc7a5fa8485f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss2.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss2.cs
@@ -1,0 +1,390 @@
+using UnityEngine;
+using Enemy;
+using System.Collections;
+using System.Collections.Generic;
+
+/// <summary>
+/// 중간보스 2 - 대시 공격과 투사체 공격을 사용하는 보스
+/// </summary>
+[DisallowMultipleComponent]
+public class Enemy_Middle_Boss2 : Enemy_Base
+{
+    [Header("차징 레일건")]
+    [SerializeField] private Enemy_Middle_Boss_Railgun railgunSystem;
+    [SerializeField] private Transform railgunFirePoint;
+    [SerializeField] private float railgunCooldown = 6f;    // 차징 시간 고려해서 조금 더 긺
+
+    [Header("대시 공격")]
+    [SerializeField] private float dashRange = 15f;
+    [SerializeField] private float dashSpeed = 20f;
+    [SerializeField] private float dashDistance = 12f;
+    [SerializeField] private float dashCooldown = 8f;
+    [SerializeField] private float dashWarningTime = 1f;
+
+    [Header("투사체 공격")]
+    [SerializeField] private GameObject bulletPrefab;
+    [SerializeField] private Transform firePoint;
+    [SerializeField] private float bulletSpeed = 12f;
+    [SerializeField] private int bulletCount = 8;
+    [SerializeField] private float bulletCooldown = 5f;
+    [SerializeField] private float bulletRange = 10f;
+
+    [Header("이펙트")]
+    [SerializeField] private GameObject dashWarningEffect;
+    [SerializeField] private GameObject dashTrailEffect;
+
+    [Header("몬스터 무시 설정")]
+    [SerializeField] private float monsterIgnoreRadius = 20f;
+    [SerializeField] private string[] monsterTags = { "Enemy", "Boss", "MiddleBoss" };
+
+    // 상태
+    private bool isDashing = false;
+    private bool isDashWarning = false;
+    private bool isShooting = false;
+
+    // 타이머
+    private float lastDashTime;
+    private float lastBulletTime;
+    private float lastRailgunTime = 0f;
+
+    // 대시 관련
+    private Vector3 dashDirection;
+    private Vector3 dashStartPosition;
+    private float dashStartTime;
+    private GameObject currentDashTrail;
+
+    // 컴포넌트
+    private Rigidbody rigid;
+    private Collider bossCollider;
+    private List<Collider> ignoredMonsterColliders = new List<Collider>();
+
+    // 프로퍼티
+    public bool IsDashing => isDashing;
+    public bool IsDashWarning => isDashWarning;
+    public bool IsShooting => isShooting;
+    public Vector3 DashDirection => dashDirection;
+    public float DashSpeed => dashSpeed;
+
+    protected override void Awake()
+    {
+        enemyType = EnemyType.MiddleBoss;
+        elementType = ElementType.Neutral;
+        primaryDamageType = DamageType.Physical;
+        enemyName = "Berserker Champion";
+
+        base.Awake();
+
+        rigid = GetComponent<Rigidbody>();
+        bossCollider = GetComponent<Collider>();
+
+        if (rigid != null)
+        {
+            rigid.constraints = RigidbodyConstraints.FreezePositionY | RigidbodyConstraints.FreezeRotationX | RigidbodyConstraints.FreezeRotationZ;
+        }
+    }
+
+    protected override void InitializeEnemy()
+    {
+        base.InitializeEnemy();
+
+        if (firePoint == null)
+            firePoint = transform;
+
+        // 레일건 시스템 초기화
+        if (railgunSystem != null)
+        {
+            railgunSystem.Initialize(this, railgunFirePoint);
+        }
+    }
+
+    protected override void UpdateBehavior()
+    {
+        if (isDashing)
+        {
+            UpdateDashBehavior();
+            return;
+        }
+
+        if (isDashWarning || isShooting || playerTransform == null) return;
+
+        float distanceToPlayer = GetDistanceToPlayer();
+
+        // 공격 패턴 우선순위
+        if (CanUseChargingRailgun())
+        {
+            UseChargingRailgun();
+        }
+        else if (distanceToPlayer >= dashRange * 0.8f && CanUseDash())
+        {
+            StartCoroutine(PerformDashAttack());
+        }
+        else if (distanceToPlayer <= bulletRange && CanUseBullets())
+        {
+            StartCoroutine(PerformBulletAttack());
+        }
+    }
+
+    protected override void UpdateMovement()
+    {
+        // Enemy_Boss2_Move에서 처리
+    }
+
+    protected override void PerformAttack()
+    {
+        // 사용하지 않음
+    }
+
+    #region 대시 공격
+
+    private bool CanUseDash()
+    {
+        return Time.time - lastDashTime >= dashCooldown && !isDashing && !isDashWarning && !isShooting;
+    }
+
+    private IEnumerator PerformDashAttack()
+    {
+        isDashWarning = true;
+        lastDashTime = Time.time;
+
+        if (playerTransform != null)
+        {
+            dashDirection = (playerTransform.position - transform.position).normalized;
+            dashDirection.y = 0;
+        }
+
+        if (dashWarningEffect != null)
+        {
+            Vector3 warningPos = transform.position + dashDirection * dashDistance * 0.5f;
+            GameObject warning = Instantiate(dashWarningEffect, warningPos, Quaternion.LookRotation(dashDirection));
+            Destroy(warning, dashWarningTime);
+        }
+
+        yield return new WaitForSeconds(dashWarningTime);
+
+        isDashWarning = false;
+        ExecuteDash();
+    }
+
+    private void ExecuteDash()
+    {
+        if (playerTransform == null) return;
+
+        isDashing = true;
+        dashStartTime = Time.time;
+        dashStartPosition = transform.position;
+
+        if (dashTrailEffect != null)
+        {
+            currentDashTrail = Instantiate(dashTrailEffect, transform.position, Quaternion.identity);
+            currentDashTrail.transform.SetParent(transform);
+        }
+
+        IgnoreMonsterCollisions(true);
+
+        float dashDuration = dashDistance / dashSpeed;
+        StartCoroutine(DashCoroutine(dashDuration));
+    }
+
+    private IEnumerator DashCoroutine(float duration)
+    {
+        float elapsed = 0f;
+        while (elapsed < duration && isDashing)
+        {
+            elapsed += Time.deltaTime;
+            yield return null;
+        }
+        EndDash();
+    }
+
+    private void UpdateDashBehavior()
+    {
+        float traveledDistance = Vector3.Distance(dashStartPosition, transform.position);
+        if (traveledDistance >= dashDistance || Time.time - dashStartTime >= 3f)
+        {
+            EndDash();
+        }
+    }
+
+    private void EndDash()
+    {
+        isDashing = false;
+
+        if (currentDashTrail != null)
+        {
+            currentDashTrail.transform.SetParent(null);
+            Destroy(currentDashTrail, 1f);
+            currentDashTrail = null;
+        }
+
+        IgnoreMonsterCollisions(false);
+    }
+
+    public void OnDashCollision(Collider other)
+    {
+        if (IsMonsterCollider(other)) return;
+
+        if (other.CompareTag("Player") && isDashing)
+        {
+            if (playerScript != null)
+            {
+                DealDamageToPlayer(DamageType.Physical);
+            }
+        }
+
+        if (other.CompareTag("Wall") || other.CompareTag("Obstacle"))
+        {
+            EndDash();
+        }
+    }
+
+    #endregion
+
+    #region 투사체 공격
+
+    private bool CanUseBullets()
+    {
+        return Time.time - lastBulletTime >= bulletCooldown && !isDashing && !isDashWarning && !isShooting;
+    }
+
+    private IEnumerator PerformBulletAttack()
+    {
+        isShooting = true;
+        lastBulletTime = Time.time;
+
+        yield return new WaitForSeconds(0.5f);
+        FireBulletsInCircle();
+        yield return new WaitForSeconds(0.5f);
+
+        isShooting = false;
+    }
+
+    private void FireBulletsInCircle()
+    {
+        if (bulletPrefab == null) return;
+
+        float angleStep = 360f / bulletCount;
+
+        for (int i = 0; i < bulletCount; i++)
+        {
+            float angle = i * angleStep;
+            Vector3 direction = new Vector3(
+                Mathf.Cos(angle * Mathf.Deg2Rad),
+                0,
+                Mathf.Sin(angle * Mathf.Deg2Rad)
+            );
+
+            GameObject bullet = Instantiate(bulletPrefab, firePoint.position, Quaternion.LookRotation(direction));
+
+            Rigidbody bulletRb = bullet.GetComponent<Rigidbody>();
+            if (bulletRb != null)
+            {
+                bulletRb.constraints = RigidbodyConstraints.FreezePositionY | RigidbodyConstraints.FreezeRotationX | RigidbodyConstraints.FreezeRotationZ;
+                bulletRb.velocity = direction * bulletSpeed;
+            }
+
+            Enemy_Middle_Boss_Bullet bulletScript = bullet.GetComponent<Enemy_Middle_Boss_Bullet>();
+            if (bulletScript != null)
+            {
+                float bulletDamage = enemyStats.Get(EnemyStatType.PhysicalDamage) * 0.4f;
+                bulletScript.Initialize(bulletDamage, DamageType.Physical);
+            }
+
+            Destroy(bullet, 5f);
+        }
+    }
+
+    #endregion
+
+    #region 차징 레일건 시스템
+
+    private bool CanUseChargingRailgun()
+    {
+        return railgunSystem != null &&
+               railgunSystem.IsReady &&
+               Time.time - lastRailgunTime >= railgunCooldown &&
+               IsPlayerInDetectionRange() &&
+               !isDashing && !isDashWarning && !isShooting;
+    }
+
+    private void UseChargingRailgun()
+    {
+        if (playerTransform != null)
+        {
+            lastRailgunTime = Time.time;
+
+            // 플레이어 위치로 차징 후 발사
+            Vector3 targetPos = playerTransform.position;
+            railgunSystem.FireInstantRailgun(targetPos);
+        }
+    }
+
+    #endregion
+
+    #region 몬스터 충돌 무시
+
+    private void IgnoreMonsterCollisions(bool ignore)
+    {
+        if (bossCollider == null) return;
+
+        if (ignore)
+        {
+            Collider[] nearbyColliders = Physics.OverlapSphere(transform.position, monsterIgnoreRadius);
+
+            foreach (Collider col in nearbyColliders)
+            {
+                if (col == bossCollider || !IsMonsterCollider(col)) continue;
+
+                if (!ignoredMonsterColliders.Contains(col))
+                {
+                    Physics.IgnoreCollision(bossCollider, col, true);
+                    ignoredMonsterColliders.Add(col);
+                }
+            }
+        }
+        else
+        {
+            foreach (Collider col in ignoredMonsterColliders)
+            {
+                if (col != null && bossCollider != null)
+                {
+                    Physics.IgnoreCollision(bossCollider, col, false);
+                }
+            }
+            ignoredMonsterColliders.Clear();
+        }
+    }
+
+    private bool IsMonsterCollider(Collider col)
+    {
+        if (col == null) return false;
+
+        foreach (string tag in monsterTags)
+        {
+            if (col.CompareTag(tag)) return true;
+        }
+
+        return col.GetComponent<Enemy_Base>() != null;
+    }
+
+    #endregion
+
+    protected override void Die()
+    {
+        isDashing = false;
+        isDashWarning = false;
+        isShooting = false;
+
+        if (currentDashTrail != null)
+        {
+            Destroy(currentDashTrail);
+        }
+
+        IgnoreMonsterCollisions(false);
+        base.Die();
+    }
+
+    protected override int GetExperienceReward()
+    {
+        return 400;
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss2.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss2.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eed45657338fc7c42bea9f7384b4800e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss2_Move.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss2_Move.cs
@@ -1,0 +1,208 @@
+using UnityEngine;
+
+/// <summary>
+/// 중간보스 2 이동 처리 스크립트
+/// </summary>
+[DisallowMultipleComponent]
+[RequireComponent(typeof(Rigidbody))]
+public class Enemy_Middle_Boss2_Move : MonoBehaviour
+{
+    [Header("이동 설정")]
+    [SerializeField] private float rotationSpeed = 4f;
+    [SerializeField] private float stoppingDistance = 2f;
+
+    private Transform target;
+    private Rigidbody rigid;
+    private Enemy_Middle_Boss2 bossScript;
+    private bool isDashingMovement = false;
+
+    private void Start()
+    {
+        target = GameObject.FindGameObjectWithTag("Player")?.transform;
+        if (target == null)
+        {
+            target = GameObject.Find("Player")?.transform;
+        }
+
+        rigid = GetComponent<Rigidbody>();
+        bossScript = GetComponent<Enemy_Middle_Boss2>();
+
+        if (rigid != null)
+        {
+            rigid.constraints = RigidbodyConstraints.FreezePositionY |
+                               RigidbodyConstraints.FreezeRotationX |
+                               RigidbodyConstraints.FreezeRotationZ;
+            rigid.drag = 5f;
+            rigid.angularDrag = 5f;
+        }
+    }
+
+    private void FixedUpdate()
+    {
+        if (bossScript == null || target == null || bossScript.IsDead())
+        {
+            StopMovement();
+            return;
+        }
+
+        if (bossScript.IsDashing)
+        {
+            HandleDashMovement();
+        }
+        else if (ShouldMove())
+        {
+            HandleNormalMovement();
+        }
+        else
+        {
+            StopMovement();
+        }
+
+        if (!bossScript.IsDashing)
+        {
+            LookAtTarget();
+        }
+    }
+
+    private bool ShouldMove()
+    {
+        return !bossScript.IsDashWarning && !bossScript.IsShooting;
+    }
+
+    private void HandleNormalMovement()
+    {
+        float distanceToPlayer = Vector3.Distance(transform.position, target.position);
+
+        if (distanceToPlayer > stoppingDistance)
+        {
+            MoveTowardsPlayer();
+        }
+        else
+        {
+            CircleAroundPlayer();
+        }
+    }
+
+    private void MoveTowardsPlayer()
+    {
+        Vector3 direction = (target.position - transform.position).normalized;
+        direction.y = 0;
+
+        float moveSpeed = bossScript.GetEnemyStats().Get(Enemy.EnemyStatType.MoveSpeed);
+        Vector3 moveVector = direction * moveSpeed * Time.fixedDeltaTime;
+
+        rigid.MovePosition(rigid.position + moveVector);
+    }
+
+    private void CircleAroundPlayer()
+    {
+        Vector3 toPlayer = target.position - transform.position;
+        toPlayer.y = 0;
+
+        Vector3 circleDirection = new Vector3(-toPlayer.z, 0, toPlayer.x).normalized;
+
+        if (Random.Range(0, 100) < 2)
+        {
+            circleDirection = -circleDirection;
+        }
+
+        float moveSpeed = bossScript.GetEnemyStats().Get(Enemy.EnemyStatType.MoveSpeed) * 0.8f;
+        Vector3 moveVector = circleDirection * moveSpeed * Time.fixedDeltaTime;
+
+        rigid.MovePosition(rigid.position + moveVector);
+    }
+
+    private void HandleDashMovement()
+    {
+        if (!isDashingMovement)
+        {
+            isDashingMovement = true;
+        }
+
+        Vector3 dashDirection = bossScript.DashDirection;
+        dashDirection.y = 0;
+        dashDirection = dashDirection.normalized;
+
+        float dashSpeed = bossScript.DashSpeed;
+        Vector3 moveVector = dashDirection * dashSpeed * Time.fixedDeltaTime;
+
+        rigid.MovePosition(rigid.position + moveVector);
+
+        if (dashDirection != Vector3.zero)
+        {
+            Quaternion targetRotation = Quaternion.LookRotation(dashDirection);
+            Vector3 eulerAngles = targetRotation.eulerAngles;
+            eulerAngles.x = 0;
+            eulerAngles.z = 0;
+            transform.rotation = Quaternion.Euler(eulerAngles);
+        }
+    }
+
+    private void LookAtTarget()
+    {
+        Vector3 direction = (target.position - transform.position).normalized;
+        direction.y = 0;
+
+        if (direction != Vector3.zero)
+        {
+            Quaternion targetRotation = Quaternion.LookRotation(direction);
+            Vector3 eulerAngles = targetRotation.eulerAngles;
+            eulerAngles.x = 0;
+            eulerAngles.z = 0;
+            targetRotation = Quaternion.Euler(eulerAngles);
+
+            transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, rotationSpeed * Time.fixedDeltaTime);
+        }
+    }
+
+    private void StopMovement()
+    {
+        if (rigid != null)
+        {
+            Vector3 vel = rigid.velocity;
+            vel.x = 0;
+            vel.z = 0;
+            rigid.velocity = vel;
+        }
+
+        if (isDashingMovement && !bossScript.IsDashing)
+        {
+            isDashingMovement = false;
+        }
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (bossScript.IsDashing)
+        {
+            bossScript.OnDashCollision(other);
+        }
+    }
+
+    private void OnCollisionEnter(Collision collision)
+    {
+        if (bossScript.IsDashing)
+        {
+            if (IsMonsterCollider(collision.collider)) return;
+
+            if (collision.gameObject.CompareTag("Wall") || collision.gameObject.CompareTag("Obstacle"))
+            {
+                bossScript.OnDashCollision(collision.collider);
+                StopMovement();
+            }
+        }
+    }
+
+    private bool IsMonsterCollider(Collider col)
+    {
+        if (col == null) return false;
+
+        string[] monsterTags = { "Enemy", "Boss", "MiddleBoss" };
+        foreach (string tag in monsterTags)
+        {
+            if (col.CompareTag(tag)) return true;
+        }
+
+        return false;
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss2_Move.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss2_Move.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8ab1788269ff634fb79fde06a40c73c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss_Move.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss_Move.cs
@@ -1,0 +1,217 @@
+using UnityEngine;
+
+/// <summary>
+/// 중간보스 이동 처리 스크립트
+/// 단순하게 플레이어를 추적하면서 공격 중에는 정지
+/// </summary>
+[DisallowMultipleComponent]
+[RequireComponent(typeof(Rigidbody))]
+public class Enemy_Middle_Boss_Move : MonoBehaviour
+{
+    [Header("이동 설정")]
+    [SerializeField] private float rotationSpeed = 4f; // 회전 속도
+    [SerializeField] private float stoppingDistance = 2f; // 정지 거리
+    [SerializeField] private float circleRadius = 5f; // 원형 이동 반지름
+
+    private Transform target;
+    private Rigidbody rigid;
+    private Enemy_Middle_Boss bossScript;
+
+    private void Start()
+    {
+        // 타겟 찾기 (플레이어)
+        target = GameObject.FindGameObjectWithTag("Player")?.transform;
+        if (target == null)
+        {
+            target = GameObject.Find("Player")?.transform;
+        }
+
+        rigid = GetComponent<Rigidbody>();
+        bossScript = GetComponent<Enemy_Middle_Boss>();
+
+        if (bossScript == null)
+        {
+            Debug.LogError("Enemy_Boss 스크립트를 찾을 수 없습니다!");
+        }
+    }
+
+    private void FixedUpdate()
+    {
+        // 기본 조건 체크
+        if (bossScript == null || target == null || bossScript.IsDead())
+        {
+            StopMovement();
+            return;
+        }
+
+        // 보스 상태에 따른 이동 처리
+        if (ShouldMove())
+        {
+            HandleNormalMovement();
+        }
+        else
+        {
+            StopMovement();
+        }
+
+        // 항상 플레이어를 바라보기
+        LookAtTarget();
+    }
+
+    #region 이동 조건 체크
+
+    /// <summary>
+    /// 이동 가능 여부 판단
+    /// </summary>
+    private bool ShouldMove()
+    {
+        // 그랩 투사체 발사 중이면 이동 불가
+        if (bossScript.IsGrabbing)
+        {
+            return false;
+        }
+
+        // 총알 발사 중이면 이동 불가
+        if (bossScript.IsShooting)
+        {
+            return false;
+        }
+
+        // 플레이어를 끌어당기는 중이면 이동 불가
+        if (bossScript.IsPlayerBeingPulled)
+        {
+            return false;
+        }
+
+        // 장판 생성 중이면 이동 불가
+        if (bossScript.IsCreatingFloorHazard)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    #endregion
+
+    #region 일반 이동
+
+    /// <summary>
+    /// 일반 추적 이동 (중간보스 스타일)
+    /// </summary>
+    private void HandleNormalMovement()
+    {
+        float distanceToPlayer = Vector3.Distance(transform.position, target.position);
+
+        // 중간보스는 단순하게 행동
+        if (distanceToPlayer > stoppingDistance)
+        {
+            // 플레이어에게 접근
+            MoveTowardsPlayer();
+        }
+        else
+        {
+            // 가까이 있을 때는 천천히 원형 이동
+            CircleAroundPlayer();
+        }
+    }
+
+    /// <summary>
+    /// 플레이어에게 접근
+    /// </summary>
+    private void MoveTowardsPlayer()
+    {
+        Vector3 direction = (target.position - transform.position).normalized;
+        direction.y = 0; // Y축 이동 제거
+
+        float moveSpeed = bossScript.GetEnemyStats().Get(Enemy.EnemyStatType.MoveSpeed);
+        Vector3 moveVector = direction * moveSpeed * Time.fixedDeltaTime;
+
+        Vector3 newPosition = rigid.position + moveVector;
+        newPosition.y = rigid.position.y; // Y축 위치 고정
+        rigid.MovePosition(newPosition);
+    }
+
+    /// <summary>
+    /// 플레이어 주변을 원형으로 이동 (중간보스 스타일)
+    /// </summary>
+    private void CircleAroundPlayer()
+    {
+        Vector3 toPlayer = target.position - transform.position;
+        toPlayer.y = 0;
+
+        // 플레이어 중심으로 원형 이동 (중간보스는 느리게)
+        Vector3 circleDirection = new Vector3(-toPlayer.z, 0, toPlayer.x).normalized;
+
+        // 가끔 방향 변환 (1% 확률)
+        if (Random.Range(0, 100) < 1)
+        {
+            circleDirection = -circleDirection;
+        }
+
+        float moveSpeed = bossScript.GetEnemyStats().Get(Enemy.EnemyStatType.MoveSpeed) * 0.7f; // 원형 이동은 느리게
+        Vector3 moveVector = circleDirection * moveSpeed * Time.fixedDeltaTime;
+
+        Vector3 newPosition = rigid.position + moveVector;
+        newPosition.y = rigid.position.y; // Y축 위치 고정
+        rigid.MovePosition(newPosition);
+    }
+
+    #endregion
+
+    #region 회전 처리
+
+    /// <summary>
+    /// 플레이어를 향해 회전
+    /// </summary>
+    private void LookAtTarget()
+    {
+        Vector3 direction = (target.position - transform.position).normalized;
+        direction.y = 0; // Y축 회전 제거
+
+        if (direction != Vector3.zero)
+        {
+            Quaternion targetRotation = Quaternion.LookRotation(direction);
+            transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, rotationSpeed * Time.fixedDeltaTime);
+        }
+    }
+
+    #endregion
+
+    #region 유틸리티
+
+    /// <summary>
+    /// 이동 정지
+    /// </summary>
+    private void StopMovement()
+    {
+        if (rigid != null)
+        {
+            rigid.velocity = Vector3.zero;
+        }
+    }
+
+    #endregion
+
+    #region 디버그
+
+    private void OnDrawGizmos()
+    {
+        if (target != null)
+        {
+            // 플레이어와의 거리 시각화
+            Gizmos.color = Color.yellow;
+            Gizmos.DrawLine(transform.position, target.position);
+
+            // 정지 거리 시각화
+            Gizmos.color = Color.green;
+            Gizmos.DrawWireSphere(transform.position, stoppingDistance);
+
+            // 원형 이동 반지름 시각화
+            Gizmos.color = Color.blue;
+            Gizmos.DrawWireSphere(transform.position, circleRadius);
+        }
+    }
+
+    #endregion
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss_Move.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Boss/Enemy_Middle_Boss_Move.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dce7d4f4ac687b647a55a13d281cc863
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Melee_Types.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Melee_Types.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6cf34d575a138b542bda6fbf210e1207
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Assassin.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Assassin.cs
@@ -1,0 +1,101 @@
+using UnityEngine;
+using Enemy;
+
+/// <summary>
+/// 단순화된 근접 적 - 기본 스탯만 사용하는 적
+/// </summary>
+[DisallowMultipleComponent]
+public class Enemy_Assassin : Enemy_Base
+{
+    [Header("기본 공격 설정")]
+    [SerializeField] private float attackDuration = 0.3f; // 공격 지속시간
+
+    // 상태 관리
+    private bool isAttacking = false;
+    private float lastAttackTime;
+
+    // Move 스크립트에서 참조할 수 있는 프로퍼티들
+    public bool IsAttacking => isAttacking;
+
+    protected override void Awake()
+    {
+        // 어새신 기본 설정
+        enemyType = EnemyType.MeleeAssassin;
+        elementType = ElementType.Dark;
+        primaryDamageType = DamageType.Physical;
+        enemyName = "Simple Assassin";
+
+        base.Awake();
+    }
+
+    protected override void InitializeEnemy()
+    {
+        // 공격 지속시간을 공격속도에 따라 조정
+        attackDuration = 1f / enemyStats.Get(EnemyStatType.AttackSpeed) * 0.3f;
+
+        base.InitializeEnemy();
+    }
+
+    protected override void UpdateBehavior()
+    {
+        // 공격 중인지 체크
+        if (isAttacking)
+        {
+            if (Time.time - lastAttackTime >= attackDuration)
+            {
+                isAttacking = false;
+            }
+            return; // 공격 중이면 다른 행동 하지 않음
+        }
+
+        if (playerTransform == null) return;
+
+        // 공격 범위 내면 공격
+        if (IsPlayerInAttackRange())
+        {
+            TryAttack();
+        }
+    }
+
+    protected override void UpdateMovement()
+    {
+    }
+
+    protected override void PerformAttack()
+    {
+        if (playerScript == null) return;
+
+        // 기본 물리 공격
+        DealDamageToPlayer(DamageType.Physical);
+    }
+
+    private void TryAttack()
+    {
+        float attackSpeed = enemyStats.Get(EnemyStatType.AttackSpeed);
+        float attackCooldown = 1f / attackSpeed;
+
+        if (Time.time - lastAttackTime >= attackCooldown)
+        {
+            isAttacking = true;
+            PerformAttack();
+            lastAttackTime = Time.time;
+
+            // 일정 시간 후 공격 상태 해제
+            Invoke(nameof(EndAttack), attackDuration);
+        }
+    }
+
+    private void EndAttack()
+    {
+        isAttacking = false;
+    }
+
+
+
+
+
+    protected override int GetExperienceReward()
+    {
+        return 15; // 기본 경험치
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Assassin.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Assassin.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6521822acc56ae7449a9d24e8fce65f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Assassin_Move.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Assassin_Move.cs
@@ -1,0 +1,106 @@
+using UnityEngine;
+
+/// <summary>
+/// 단순화된 근접 적 이동 처리 스크립트 (Y축 고정 버전)
+/// 기본적인 이동만 처리
+/// </summary>
+[DisallowMultipleComponent]
+public class Enemy_Assassin_Move : MonoBehaviour
+{
+    private Transform target;
+    private Rigidbody rigid;
+    private Enemy_Assassin simpleAssassin;
+
+    private void Start()
+    {
+        target = GameObject.FindGameObjectWithTag("Player")?.transform;
+        if (target == null)
+        {
+            target = GameObject.Find("Player")?.transform;
+        }
+
+        rigid = GetComponent<Rigidbody>();
+        simpleAssassin = GetComponent<Enemy_Assassin>();
+    }
+
+    private void FixedUpdate()
+    {
+        // 기본 조건 체크
+        if (simpleAssassin == null || target == null || simpleAssassin.IsDead())
+        {
+            StopMovement();
+            return;
+        }
+
+        // 이동 가능한지 체크
+        if (ShouldMove())
+        {
+            NormalMove();
+        }
+        else
+        {
+            StopMovement();
+        }
+    }
+
+    /// <summary>
+    /// 이동 가능 여부 판단
+    /// </summary>
+    private bool ShouldMove()
+    {
+        // 공격 중이면 이동 불가
+        if (simpleAssassin.IsAttacking)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// 일반 이동 (플레이어 추격) - Y축 고정
+    /// </summary>
+    private void NormalMove()
+    {
+        Vector3 dirVector = target.position - transform.position;
+        dirVector.y = 0; // Y축 이동 제거
+
+        if (dirVector.magnitude > 0.1f) // 너무 가까우면 이동하지 않음
+        {
+            // 이동 속도 스탯 사용
+            float moveSpeed = simpleAssassin.GetEnemyStats().Get(Enemy.EnemyStatType.MoveSpeed);
+            Vector3 moveVector = dirVector.normalized * moveSpeed * Time.fixedDeltaTime;
+
+            Vector3 newPosition = rigid.position + moveVector;
+            newPosition.y = rigid.position.y; // Y축 위치 고정
+            rigid.MovePosition(newPosition);
+
+            // 플레이어 방향으로 회전
+            LookAtTarget(dirVector);
+        }
+    }
+
+    /// <summary>
+    /// 목표 방향으로 회전
+    /// </summary>
+    private void LookAtTarget(Vector3 direction)
+    {
+        if (direction != Vector3.zero)
+        {
+            Quaternion targetRotation = Quaternion.LookRotation(direction);
+            transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, Time.fixedDeltaTime * 5f);
+        }
+    }
+
+    /// <summary>
+    /// 이동 정지
+    /// </summary>
+    private void StopMovement()
+    {
+        if (rigid != null)
+        {
+            // X, Z축 속도만 0으로 설정, Y축은 중력 유지
+            rigid.velocity = new Vector3(0, rigid.velocity.y, 0);
+        }
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Assassin_Move.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Assassin_Move.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7f6caf48265f4c46bdbf06da9a6d865
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Tanker.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Tanker.cs
@@ -1,0 +1,105 @@
+using UnityEngine;
+using Enemy;
+
+/// <summary>
+/// 단순화된 근접 탱커 - 기본 스탯만 사용하는 적
+/// 높은 체력과 방어력을 가진 내구형 적
+/// </summary>
+[DisallowMultipleComponent]
+public class Enemy_Tanker : Enemy_Base
+{
+    [Header("기본 공격 설정")]
+    [SerializeField] private float attackDuration = 0.5f; // 공격 지속시간
+
+    // 상태 관리
+    private bool isAttacking = false;
+    private float lastAttackTime;
+
+    // Move 스크립트에서 참조할 수 있는 프로퍼티들
+    public bool IsAttacking => isAttacking;
+
+    protected override void Awake()
+    {
+        // 탱커 기본 설정
+        enemyType = EnemyType.MeleeTanker;
+        elementType = ElementType.Neutral;
+        primaryDamageType = DamageType.Physical;
+        enemyName = "Simple Tanker";
+
+        base.Awake();
+    }
+
+    protected override void InitializeEnemy()
+    {
+        // 공격 지속시간을 공격속도에 따라 조정
+        attackDuration = 1f / enemyStats.Get(EnemyStatType.AttackSpeed) * 0.5f;
+
+        base.InitializeEnemy();
+    }
+
+    protected override void UpdateBehavior()
+    {
+        // 공격 중인지 체크
+        if (isAttacking)
+        {
+            if (Time.time - lastAttackTime >= attackDuration)
+            {
+                isAttacking = false;
+                Debug.Log($"{enemyName}: 공격 완료");
+            }
+            return; // 공격 중이면 다른 행동 하지 않음
+        }
+
+        if (playerTransform == null) return;
+
+        // 공격 범위 내면 공격
+        if (IsPlayerInAttackRange())
+        {
+            TryAttack();
+        }
+    }
+
+    protected override void UpdateMovement()
+    {
+        // 이동은 Enemy_Tanker_Move에서 처리하므로 비워둠
+    }
+
+    protected override void PerformAttack()
+    {
+        if (playerScript == null) return;
+
+        // 강력한 물리 공격 (탱커는 데미지가 높음)
+        DealDamageToPlayer(DamageType.Physical);
+        Debug.Log($"{enemyName}: 강력한 물리 공격!");
+    }
+
+    private void TryAttack()
+    {
+        float attackSpeed = enemyStats.Get(EnemyStatType.AttackSpeed);
+        float attackCooldown = 1f / attackSpeed;
+
+        if (Time.time - lastAttackTime >= attackCooldown)
+        {
+            isAttacking = true;
+            PerformAttack();
+            lastAttackTime = Time.time;
+
+            // 일정 시간 후 공격 상태 해제
+            Invoke(nameof(EndAttack), attackDuration);
+        }
+    }
+
+    private void EndAttack()
+    {
+        isAttacking = false;
+    }
+
+
+
+
+
+    protected override int GetExperienceReward()
+    {
+        return 20; // 탱커는 더 많은 경험치
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Tanker.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Tanker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 799e5dc42f9f4144eb2fee870a297f41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Tanker_Move.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Tanker_Move.cs
@@ -1,0 +1,104 @@
+using UnityEngine;
+
+/// <summary>
+/// 단순화된 근접 탱커 이동 처리 스크립트
+/// 기본적인 이동만 처리
+/// </summary>
+[DisallowMultipleComponent]
+public class Enemy_Tanker_Move : MonoBehaviour
+{
+    private Transform target;
+    private Rigidbody rigid;
+    private Enemy_Tanker simpleTanker;
+
+    private void Start()
+    {
+        target = GameObject.FindGameObjectWithTag("Player")?.transform;
+        if (target == null)
+        {
+            target = GameObject.Find("Player")?.transform;
+        }
+
+        rigid = GetComponent<Rigidbody>();
+        simpleTanker = GetComponent<Enemy_Tanker>();
+    }
+
+    private void FixedUpdate()
+    {
+        // 기본 조건 체크
+        if (simpleTanker == null || target == null || simpleTanker.IsDead())
+        {
+            StopMovement();
+            return;
+        }
+
+        // 이동 가능한지 체크
+        if (ShouldMove())
+        {
+            NormalMove();
+        }
+        else
+        {
+            StopMovement();
+        }
+    }
+
+    /// <summary>
+    /// 이동 가능 여부 판단
+    /// </summary>
+    private bool ShouldMove()
+    {
+        // 공격 중이면 이동 불가
+        if (simpleTanker.IsAttacking)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// 일반 이동 (천천히 플레이어 추격)
+    /// </summary>
+    private void NormalMove()
+    {
+        Vector3 dirVector = target.position - transform.position;
+        dirVector.y = 0; // Y축 이동 제거
+
+        if (dirVector.magnitude > 0.1f) // 너무 가까우면 이동하지 않음
+        {
+            // 탱커의 기본 이동 속도 사용 (일반적으로 느림)
+            float moveSpeed = simpleTanker.GetEnemyStats().Get(Enemy.EnemyStatType.MoveSpeed);
+            Vector3 moveVector = dirVector.normalized * moveSpeed * Time.fixedDeltaTime;
+
+            rigid.MovePosition(rigid.position + moveVector);
+
+            // 플레이어 방향으로 회전
+            LookAtTarget(dirVector);
+        }
+    }
+
+    /// <summary>
+    /// 목표 방향으로 회전
+    /// </summary>
+    private void LookAtTarget(Vector3 direction)
+    {
+        if (direction != Vector3.zero)
+        {
+            Quaternion targetRotation = Quaternion.LookRotation(direction);
+            // 탱커는 회전도 느리게
+            transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, Time.fixedDeltaTime * 3f);
+        }
+    }
+
+    /// <summary>
+    /// 이동 정지
+    /// </summary>
+    private void StopMovement()
+    {
+        if (rigid != null)
+        {
+            rigid.velocity = Vector3.zero;
+        }
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Tanker_Move.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Melee_Types/Enemy_Tanker_Move.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef9be796a31dc324594e7c395bb86785
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b0083a4653e129841a47037e7caa0048
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Enemy_Ranged_Bullet.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Enemy_Ranged_Bullet.cs
@@ -1,0 +1,99 @@
+using UnityEngine;
+using Enemy;
+
+/// <summary>
+/// 원거리 몬스터가 발사하는 투사체
+/// </summary>
+public class Enemy_Ranged_Bullet : MonoBehaviour
+{
+    [Header("기본 설정")]
+    [SerializeField] private float speed = 8f;
+    [SerializeField] private float damage = 25f;
+    [SerializeField] private float lifeTime = 3f;
+
+    [Header("데미지 시스템")]
+    [SerializeField] private DamageType damageType = DamageType.Physical;
+    [SerializeField] private ElementType elementType = ElementType.Neutral;
+    [SerializeField] private bool useAdvancedDamageSystem = true;
+
+    private void Start()
+    {
+        Destroy(gameObject, lifeTime);
+    }
+
+    private void Update()
+    {
+        transform.position += transform.forward * speed * Time.deltaTime;
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Enemy")) return;
+
+        if (other.CompareTag("Player"))
+        {
+            Player.Player player = other.GetComponent<Player.Player>();
+            if (player != null)
+            {
+                if (useAdvancedDamageSystem)
+                {
+                    ApplyDamageSystem(player);
+                }
+                else
+                {
+                    player.DecreaseHP(damage);
+                }
+            }
+            Destroy(gameObject);
+        }
+        else if (other.CompareTag("Wall") || other.CompareTag("Ground"))
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    private void ApplyDamageSystem(Player.Player player)
+    {
+        EnemyStatSystem tempStats = new EnemyStatSystem(EnemyType.RangedAD);
+
+        float calculatedDamage = DamageCalculator.CalculateDamageToPlayer(
+            tempStats,
+            elementType,
+            damageType,
+            player.GetPlayerStat(),
+            ElementType.Neutral
+        );
+
+        // 계산된 데미지 적용 (수정됨)
+        player.DecreaseHP(calculatedDamage);
+
+    }
+
+    #region 설정 메서드들
+    public void Initialize(float newDamage, float newSpeed, DamageType newDamageType, ElementType newElement)
+    {
+        damage = newDamage;
+        speed = newSpeed;
+        damageType = newDamageType;
+        elementType = newElement;
+        useAdvancedDamageSystem = true;
+    }
+
+    public void SetDamage(float newDamage) => damage = newDamage;
+    public void SetSpeed(float newSpeed) => speed = newSpeed;
+    public void SetDamageType(DamageType newDamageType)
+    {
+        damageType = newDamageType;
+        useAdvancedDamageSystem = true;
+    }
+    public void SetElementType(ElementType newElementType)
+    {
+        elementType = newElementType;
+        useAdvancedDamageSystem = true;
+    }
+
+    public DamageType GetDamageType() => damageType;
+    public ElementType GetElementType() => elementType;
+    public bool IsUsingAdvancedSystem() => useAdvancedDamageSystem;
+    #endregion
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Enemy_Ranged_Bullet.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Enemy_Ranged_Bullet.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c1ebcd34d8b6394685a9817d863bde8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Enemy_Wizard_MagicOrb.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Enemy_Wizard_MagicOrb.cs
@@ -1,0 +1,166 @@
+using UnityEngine;
+using Enemy;
+
+/// <summary>
+/// 마법사가 발사하는 마법 구슬
+/// </summary>
+public class Enemy_Wizard_MagicOrb : MonoBehaviour
+{
+    [Header("기본 설정")]
+    [SerializeField] private float speed = 6f;
+    [SerializeField] private float damage = 50f;
+    [SerializeField] private float lifeTime = 4f;
+
+    [Header("마법 구슬 속성")]
+    [SerializeField] private DamageType damageType = DamageType.Magical;
+    [SerializeField] private ElementType elementType = ElementType.Neutral;
+    [SerializeField] private bool useAdvancedDamageSystem = true;
+
+    [Header("유도 기능")]
+    [SerializeField] private bool isHoming = true;
+    [SerializeField] private float homingStrength = 2f;
+
+    [Header("시각적 효과")]
+    [SerializeField] private GameObject impactEffect;
+    [SerializeField] private AudioClip launchSound;
+    [SerializeField] private AudioClip impactSound;
+
+    private Transform target;
+    private bool hasHitTarget = false;
+
+    private void Start()
+    {
+        // 플레이어 타겟 찾기
+        GameObject playerObj = GameObject.Find("Player");
+        if (playerObj != null)
+        {
+            target = playerObj.transform;
+        }
+
+        PlayLaunchSound();
+        Destroy(gameObject, lifeTime);
+    }
+
+    private void Update()
+    {
+        MoveMagicOrb();
+    }
+
+    private void MoveMagicOrb()
+    {
+        Vector3 moveDirection = transform.forward;
+
+        if (isHoming && target != null && !hasHitTarget)
+        {
+            Vector3 directionToTarget = (target.position - transform.position).normalized;
+            moveDirection = Vector3.Slerp(moveDirection, directionToTarget, homingStrength * Time.deltaTime).normalized;
+            transform.rotation = Quaternion.LookRotation(moveDirection);
+        }
+
+        transform.position += moveDirection * speed * Time.deltaTime;
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Enemy")) return;
+
+        if (other.CompareTag("Player"))
+        {
+            HitPlayer(other);
+        }
+        else if (other.CompareTag("Wall") || other.CompareTag("Ground"))
+        {
+            HitObstacle();
+        }
+    }
+
+    private void HitPlayer(Collider playerCollider)
+    {
+        Player.Player player = playerCollider.GetComponent<Player.Player>();
+        if (player != null)
+        {
+            hasHitTarget = true;
+
+            if (useAdvancedDamageSystem)
+            {
+                ApplyDamageSystem(player);
+            }
+            else
+            {
+                player.DecreaseHP(damage);
+            }
+
+        }
+
+        CreateImpactEffect();
+        Destroy(gameObject);
+    }
+
+    private void HitObstacle()
+    {
+        CreateImpactEffect();
+        Destroy(gameObject);
+    }
+
+    private void ApplyDamageSystem(Player.Player player)
+    {
+        EnemyStatSystem tempWizardStats = new EnemyStatSystem(EnemyType.RangedAP);
+
+        float calculatedDamage = DamageCalculator.CalculateDamageToPlayer(
+            tempWizardStats,
+            elementType,
+            damageType,
+            player.GetPlayerStat(),
+            ElementType.Neutral
+        );
+
+        // 계산된 데미지 적용 (수정됨)
+        player.DecreaseHP(calculatedDamage);
+
+    }
+
+    private void PlayLaunchSound()
+    {
+        if (launchSound != null)
+        {
+            AudioSource.PlayClipAtPoint(launchSound, transform.position);
+        }
+    }
+
+    private void CreateImpactEffect()
+    {
+        if (impactEffect != null)
+        {
+            GameObject effect = Instantiate(impactEffect, transform.position, Quaternion.identity);
+            Destroy(effect, 2f);
+        }
+
+        if (impactSound != null)
+        {
+            AudioSource.PlayClipAtPoint(impactSound, transform.position);
+        }
+    }
+
+    #region 설정 메서드들
+    public void Initialize(float newDamage, float newSpeed, DamageType newDamageType, ElementType newElement)
+    {
+        damage = newDamage;
+        speed = newSpeed;
+        damageType = newDamageType;
+        elementType = newElement;
+        useAdvancedDamageSystem = true;
+    }
+
+    public void SetHomingProperties(bool enableHoming, float strength = 2f)
+    {
+        isHoming = enableHoming;
+        homingStrength = strength;
+    }
+
+    public void SetBasicProperties(float newDamage, float newSpeed)
+    {
+        damage = newDamage;
+        speed = newSpeed;
+    }
+    #endregion
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Enemy_Wizard_MagicOrb.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Enemy_Wizard_MagicOrb.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed8d99a2d1c28614c86d4e3638632165
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 614556cdf6060cd4182e5c532e99acb5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_Bullet.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_Bullet.cs
@@ -1,0 +1,188 @@
+using UnityEngine;
+using Enemy;
+
+/// <summary>
+/// 다크오브에서 발사하는 단순한 탄막
+/// </summary>
+[RequireComponent(typeof(Rigidbody))]
+[RequireComponent(typeof(Collider))]
+public class Enemy_Final_Boss_Bullet : MonoBehaviour
+{
+    [Header("탄막 설정")]
+    [SerializeField] private float damage = 40f;
+    [SerializeField] private DamageType damageType = DamageType.Magical;
+    [SerializeField] private ElementType elementType = ElementType.Dark;
+    [SerializeField] private float lifeTime = 5f;
+
+    [Header("시각 효과")]
+    [SerializeField] private GameObject hitEffect;
+    [SerializeField] private TrailRenderer trail;
+    [SerializeField] private bool rotateWhileFlying = true;
+    [SerializeField] private float rotationSpeed = 360f;
+
+    private bool hasHit = false;
+    private Enemy_Base sourceBoss;
+
+    public void Initialize(float bulletDamage, Vector3 bulletVelocity)
+    {
+        damage = bulletDamage;
+
+        // 속도 적용
+        Rigidbody rb = GetComponent<Rigidbody>();
+        if (rb != null)
+        {
+            rb.velocity = bulletVelocity;
+        }
+
+        SetupComponents();
+
+        // 수명 설정
+        Destroy(gameObject, lifeTime);
+    }
+
+    private void SetupComponents()
+    {
+
+        // 트리거로 설정
+        GetComponent<Collider>().isTrigger = true;
+
+        // 기본 시각 효과 생성 (프리팹에 없을 경우)
+        if (GetComponentInChildren<Renderer>() == null)
+        {
+            CreateBulletVisual();
+        }
+
+        // 트레일 설정
+        if (trail == null)
+        {
+            trail = GetComponent<TrailRenderer>();
+        }
+        if (trail != null)
+        {
+            trail.time = 0.5f;
+            trail.startWidth = 0.2f;
+            trail.endWidth = 0.05f;
+            trail.startColor = new Color(0.5f, 0f, 0.5f, 1f);
+            trail.endColor = new Color(0.5f, 0f, 0.5f, 0f);
+        }
+    }
+
+    private void CreateBulletVisual()
+    {
+        GameObject visual = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        visual.transform.SetParent(transform);
+        visual.transform.localPosition = Vector3.zero;
+        visual.transform.localScale = Vector3.one * 0.5f;
+
+        // 머티리얼 설정
+        Renderer renderer = visual.GetComponent<Renderer>();
+        Material material = new Material(Shader.Find("Standard"));
+        material.color = new Color(0.5f, 0f, 0.5f);
+        material.EnableKeyword("_EMISSION");
+        material.SetColor("_EmissionColor", Color.magenta * 2f);
+        renderer.material = material;
+
+        // 콜라이더 제거 (부모에 있음)
+        DestroyImmediate(visual.GetComponent<Collider>());
+    }
+
+    private void Update()
+    {
+        // 회전 효과
+        if (rotateWhileFlying && !hasHit)
+        {
+            transform.Rotate(Vector3.forward, rotationSpeed * Time.deltaTime);
+        }
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (hasHit) return;
+
+        if (other.CompareTag("Player"))
+        {
+            Player.Player player = other.GetComponent<Player.Player>();
+            if (player != null)
+            {
+                ApplyDamageSystem(player);
+            }
+            HitTarget();
+        }
+        else if (other.CompareTag("Wall") || other.CompareTag("Obstacle"))
+        {
+            HitTarget();
+        }
+    }
+
+    private void ApplyDamageSystem(Player.Player player)
+    {
+        // 임시 보스 스탯 생성
+        EnemyStatSystem tempEnemyStats = new EnemyStatSystem(EnemyType.MiddleBoss);
+
+        // 정확한 데미지 계산
+        float calculatedDamage = DamageCalculator.CalculateDamageToPlayer(
+            tempEnemyStats,
+            elementType,
+            damageType,
+            player.GetPlayerStat(),
+            ElementType.Neutral
+        );
+
+        // 계산된 데미지 적용
+        player.DecreaseHP(calculatedDamage);
+        Debug.Log($"플레이어가 다크불릿에 맞음! 데미지: {calculatedDamage}");
+    }
+
+    private void HitTarget()
+    {
+        if (hasHit) return;
+        hasHit = true;
+
+        // 충돌 이펙트 생성
+        if (hitEffect != null)
+        {
+            GameObject effect = Instantiate(hitEffect, transform.position, Quaternion.identity);
+            Destroy(effect, 2f);
+        }
+        else
+        {
+            CreateSimpleHitEffect();
+        }
+
+        // 궤적 효과 정리
+        if (trail != null)
+        {
+            trail.autodestruct = true;
+        }
+
+        // 탄막 오브젝트 파괴
+        Destroy(gameObject);
+    }
+
+    private void CreateSimpleHitEffect()
+    {
+        // 간단한 폭발 이펙트
+        GameObject explosion = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        explosion.name = "BulletHitEffect";
+        explosion.transform.position = transform.position;
+        explosion.transform.localScale = Vector3.one * 1.5f;
+
+        Renderer renderer = explosion.GetComponent<Renderer>();
+        Material material = new Material(Shader.Find("Standard"));
+        material.color = Color.magenta;
+        material.EnableKeyword("_EMISSION");
+        material.SetColor("_EmissionColor", Color.magenta * 3f);
+        renderer.material = material;
+
+        DestroyImmediate(explosion.GetComponent<Collider>());
+        Destroy(explosion, 0.5f);
+    }
+
+    private void OnBecameInvisible()
+    {
+        if (!hasHit)
+        {
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_Bullet.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_Bullet.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63e0c264f16f7784986c937113b7a851
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_DarkFloor.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_DarkFloor.cs
@@ -1,0 +1,324 @@
+using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+/// <summary>
+/// 최종보스 적 바닥 - 보스 추적 상시 지속
+/// </summary>
+public class Enemy_Final_Boss_DarkFloor : MonoBehaviour
+{
+    [Header("지속 설정")]
+    [SerializeField] private float floorRadius = 6f;
+    [SerializeField] private float damageInterval = 0.5f;
+    [SerializeField] private float followSpeed = 3f;
+    [SerializeField] private float detectionInterval = 0.1f; // 플레이어 감지 주기
+
+    [Header("이펙트")]
+    [SerializeField] private GameObject floorEffect;
+    [SerializeField] private Light floorLight;
+    [SerializeField] private AudioClip ambientSound;
+
+    [Header("시각적 설정")]
+    [SerializeField] private float pulseIntensity = 0.3f;
+
+    private float damage;
+    private Transform bossTransform;
+    private bool isActive = false;
+    private Dictionary<Transform, float> lastDamageTime = new Dictionary<Transform, float>();
+    private AudioSource audioSource;
+    private List<Transform> playersInRange = new List<Transform>();
+    private float lastDetectionTime = 0f;
+
+    public void Initialize(float floorDamage, Transform boss)
+    {
+        damage = floorDamage;
+        bossTransform = boss;
+
+        SetupComponents();
+        StartCoroutine(ActivateFloor());
+    }
+
+    private void SetupComponents()
+    {
+        // 오디오 설정
+        audioSource = GetComponent<AudioSource>();
+        if (audioSource == null)
+            audioSource = gameObject.AddComponent<AudioSource>();
+        audioSource.spatialBlend = 1f;
+        audioSource.loop = true;
+
+        // 콜라이더 제거 - 순수 거리 계산 방식 사용
+
+        // 지속 조명 설정
+        if (floorLight == null)
+            floorLight = gameObject.AddComponent<Light>();
+
+        floorLight.type = LightType.Point;
+        floorLight.color = Color.red;
+        floorLight.intensity = 2f;
+        floorLight.range = floorRadius * 2f;
+
+        // 시각적 이펙트 설정
+        if (floorEffect != null)
+        {
+            floorEffect.SetActive(false);
+            floorEffect.transform.localScale = Vector3.one * floorRadius * 2f;
+        }
+
+        // 보스 위치로 이동
+        if (bossTransform != null)
+        {
+            Vector3 pos = bossTransform.position;
+            pos.y = 0.1f; // 지면보다 살짝 위
+            transform.position = pos;
+        }
+    }
+
+    private IEnumerator ActivateFloor()
+    {
+        isActive = true;
+
+        // 이펙트 활성화
+        if (floorEffect != null)
+            floorEffect.SetActive(true);
+
+        // 주변 사운드 시작
+        if (ambientSound != null && audioSource != null)
+        {
+            audioSource.clip = ambientSound;
+            audioSource.volume = 0.3f;
+            audioSource.Play();
+        }
+
+        // 지속 확산 애니메이션
+        float expandTime = 1f;
+        float elapsed = 0f;
+        Vector3 targetScale = Vector3.one * floorRadius * 2f;
+
+        while (elapsed < expandTime)
+        {
+            float progress = elapsed / expandTime;
+
+            if (floorEffect != null)
+            {
+                floorEffect.transform.localScale = targetScale * progress;
+            }
+
+            if (floorLight != null)
+            {
+                floorLight.intensity = Mathf.Lerp(0f, 2f, progress);
+            }
+
+            elapsed += Time.deltaTime;
+            yield return null;
+        }
+
+        // 완전 활성화
+        if (floorEffect != null)
+            floorEffect.transform.localScale = targetScale;
+    }
+
+    private void Update()
+    {
+        if (!isActive) return;
+
+        FollowBoss();
+        UpdateVisualEffects();
+        DetectPlayersInRange(); // 거리 기반 플레이어 감지
+        ProcessDamage();
+    }
+
+    private void FollowBoss()
+    {
+        if (bossTransform == null) return;
+
+        Vector3 targetPosition = bossTransform.position;
+        targetPosition.y = 0.1f; // Y축 고정
+
+        // 부드럽게 보스 따라가기
+        Vector3 newPosition = Vector3.Lerp(transform.position, targetPosition,
+            followSpeed * Time.deltaTime);
+
+        transform.position = newPosition;
+    }
+
+    private void DetectPlayersInRange()
+    {
+        // 감지 주기 제어 (성능 최적화)
+        if (Time.time - lastDetectionTime < detectionInterval)
+            return;
+
+        lastDetectionTime = Time.time;
+
+        // 현재 범위 내 플레이어들 체크
+        GameObject[] players = GameObject.FindGameObjectsWithTag("Player");
+        List<Transform> currentPlayersInRange = new List<Transform>();
+
+        foreach (GameObject playerObj in players)
+        {
+            if (playerObj == null) continue;
+
+            float distance = Vector3.Distance(transform.position, playerObj.transform.position);
+
+            // 플레이어가 범위 내에 있는지 체크
+            if (distance <= floorRadius)
+            {
+                currentPlayersInRange.Add(playerObj.transform);
+            }
+        }
+
+        // 새로 들어온 플레이어들 처리
+        foreach (Transform player in currentPlayersInRange)
+        {
+            if (!playersInRange.Contains(player))
+            {
+                playersInRange.Add(player);
+                Debug.Log($"플레이어 {player.name}이 장판에 진입했습니다.");
+            }
+        }
+
+        // 벗어난 플레이어들 처리
+        for (int i = playersInRange.Count - 1; i >= 0; i--)
+        {
+            Transform player = playersInRange[i];
+            if (player == null || !currentPlayersInRange.Contains(player))
+            {
+                playersInRange.RemoveAt(i);
+                if (lastDamageTime.ContainsKey(player))
+                    lastDamageTime.Remove(player);
+
+                if (player != null)
+                    Debug.Log($"플레이어 {player.name}이 장판에서 벗어났습니다.");
+            }
+        }
+    }
+
+    private void UpdateVisualEffects()
+    {
+        // 맥동 효과
+        if (floorLight != null)
+        {
+            float pulse = Mathf.Sin(Time.time * 3f) * pulseIntensity + (2f - pulseIntensity);
+            floorLight.intensity = pulse;
+        }
+    }
+
+    private void ProcessDamage()
+    {
+        if (playersInRange.Count == 0) return;
+
+        // 안전한 순회를 위해 리스트 복사
+        List<Transform> playersToProcess = new List<Transform>(playersInRange);
+
+        foreach (Transform playerTransform in playersToProcess)
+        {
+            if (playerTransform == null) continue;
+
+            // 데미지 간격 체크
+            if (!lastDamageTime.ContainsKey(playerTransform))
+                lastDamageTime[playerTransform] = 0f;
+
+            if (Time.time - lastDamageTime[playerTransform] >= damageInterval)
+            {
+                DealDamageToPlayer(playerTransform);
+                lastDamageTime[playerTransform] = Time.time;
+            }
+        }
+    }
+
+    private void DealDamageToPlayer(Transform playerTransform)
+    {
+        Player.Player player = playerTransform.GetComponent<Player.Player>();
+        if (player != null)
+        {
+            player.DecreaseHP(damage);
+            StartCoroutine(DamageFlash());
+        }
+    }
+
+    private IEnumerator DamageFlash()
+    {
+        // 데미지를 줄 때 지속이 더 밝아짐
+        if (floorLight != null)
+        {
+            float originalIntensity = floorLight.intensity;
+            Color originalColor = floorLight.color;
+
+            floorLight.intensity = 4f;
+            floorLight.color = Color.white;
+
+            yield return new WaitForSeconds(0.1f);
+
+            floorLight.intensity = originalIntensity;
+            floorLight.color = originalColor;
+        }
+    }
+
+    public void DeactivateFloor()
+    {
+        if (!isActive) return;
+        StartCoroutine(DeactivateSequence());
+    }
+
+    private IEnumerator DeactivateSequence()
+    {
+        isActive = false;
+
+        // 사운드 정지
+        if (audioSource != null)
+            audioSource.Stop();
+
+        // 축소 애니메이션
+        float shrinkTime = 0.8f;
+        float elapsed = 0f;
+        Vector3 originalScale = floorEffect != null ? floorEffect.transform.localScale : Vector3.one;
+        float originalIntensity = floorLight != null ? floorLight.intensity : 0f;
+
+        while (elapsed < shrinkTime)
+        {
+            float progress = elapsed / shrinkTime;
+            float scale = Mathf.Lerp(1f, 0f, progress);
+
+            if (floorEffect != null)
+                floorEffect.transform.localScale = originalScale * scale;
+
+            if (floorLight != null)
+                floorLight.intensity = Mathf.Lerp(originalIntensity, 0f, progress);
+
+            elapsed += Time.deltaTime;
+            yield return null;
+        }
+
+        // 완전히 비활성화
+        if (floorEffect != null)
+            floorEffect.SetActive(false);
+
+        if (floorLight != null)
+            floorLight.enabled = false;
+
+        Destroy(gameObject);
+    }
+
+    private void OnDestroy()
+    {
+        playersInRange.Clear();
+        lastDamageTime.Clear();
+    }
+
+    // 디버깅을 위한 Gizmos - 장판 범위 시각화
+    private void OnDrawGizmos()
+    {
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireSphere(transform.position, floorRadius);
+
+        if (playersInRange != null && playersInRange.Count > 0)
+        {
+            Gizmos.color = Color.yellow;
+            foreach (Transform player in playersInRange)
+            {
+                if (player != null)
+                    Gizmos.DrawLine(transform.position, player.position);
+            }
+        }
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_DarkFloor.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_DarkFloor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff9980c78138cc24c9ea86ed9599f4f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_DarkOrb.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_DarkOrb.cs
@@ -1,0 +1,447 @@
+using UnityEngine;
+using System.Collections;
+
+/// <summary>
+/// 최종보스의 어둠 구체 - 다크 불릿 공격 (프리팹 자체 관리)
+/// </summary>
+public class Enemy_Final_Boss_DarkOrb : MonoBehaviour
+{
+    [Header("구체 설정")]
+    [SerializeField] private float health = 100f;
+    [SerializeField] private float moveSpeed = 3f;
+    [SerializeField] private float heightFixed = 2f;
+    [SerializeField] private float minDistanceToPlayer = 6f;
+    [SerializeField] private float maxDistanceToPlayer = 15f;
+    [SerializeField] private float randomMoveInterval = 2f;
+
+    [Header("다크 불릿 공격")]
+    [SerializeField] private GameObject darkBulletPrefab;  // 자체 관리
+    [SerializeField] private float darkBulletDamage = 40f;
+    [SerializeField] private int darkBulletCount = 12;
+    [SerializeField] private float darkBulletSpeed = 8f;
+    [SerializeField] private float darkBulletCooldown = 2f;
+
+    [Header("시각적 효과")]
+    [SerializeField] private Material orbMaterial;
+    [SerializeField] private Color orbColor = Color.red;
+    [SerializeField] private float emissionIntensity = 0.3f;
+
+    private Enemy_Final_Boss_Neutral ownerBoss;
+    private Transform player;
+    private Vector3 currentTargetPosition;
+    private float lastRandomMoveTime;
+    private float lastBulletTime;
+    private bool isFiring = false;
+    private bool isDestroyed = false;
+
+    // 초기화 간소화 - 보스 참조와 기본 설정만
+    public void Initialize(Enemy_Final_Boss_Neutral boss)
+    {
+        ownerBoss = boss;
+        SetupComponents();
+        StartBehavior();
+    }
+
+    // 런타임에서 설정 변경 가능한 메서드들
+    public void SetHealth(float newHealth) => health = newHealth;
+    public void SetMoveSpeed(float newSpeed) => moveSpeed = newSpeed;
+    public void SetBulletSettings(float damage, int count, float speed, float cooldown)
+    {
+        darkBulletDamage = damage;
+        darkBulletCount = count;
+        darkBulletSpeed = speed;
+        darkBulletCooldown = cooldown;
+    }
+
+    private void SetupComponents()
+    {
+        // 플레이어 찾기
+        player = GameObject.FindGameObjectWithTag("Player")?.transform;
+
+        // 초기 위치 설정
+        SetRandomTargetPosition();
+        transform.position = new Vector3(currentTargetPosition.x, heightFixed, currentTargetPosition.z);
+
+        // 리지드바디 설정
+        SetupRigidbody();
+
+        // 렌더러 설정
+        SetupRenderer();
+
+        // 조명 설정
+        SetupLight();
+
+        // 콜라이더 설정
+        SetupCollider();
+    }
+
+    private void SetupRigidbody()
+    {
+        Rigidbody rb = GetComponent<Rigidbody>();
+        if (rb == null)
+            rb = gameObject.AddComponent<Rigidbody>();
+
+        rb.useGravity = false;
+        rb.constraints = RigidbodyConstraints.FreezeRotationX |
+                        RigidbodyConstraints.FreezeRotationZ |
+                        RigidbodyConstraints.FreezePositionY;
+    }
+
+    private void SetupRenderer()
+    {
+        Renderer renderer = GetComponent<Renderer>();
+        if (renderer == null)
+        {
+            // 기본 구체 생성
+            GameObject sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            sphere.transform.SetParent(transform);
+            sphere.transform.localPosition = Vector3.zero;
+            sphere.transform.localScale = Vector3.one * 2f;
+            renderer = sphere.GetComponent<Renderer>();
+        }
+
+        // 머티리얼 설정
+        if (orbMaterial != null)
+        {
+            renderer.material = orbMaterial;
+        }
+        else
+        {
+            Material material = new Material(Shader.Find("Standard"));
+            material.color = orbColor;
+            material.EnableKeyword("_EMISSION");
+            material.SetColor("_EmissionColor", orbColor * emissionIntensity);
+            renderer.material = material;
+        }
+    }
+
+    private void SetupLight()
+    {
+        Light orbLight = GetComponent<Light>();
+        if (orbLight == null)
+            orbLight = gameObject.AddComponent<Light>();
+
+        orbLight.type = LightType.Point;
+        orbLight.color = orbColor;
+        orbLight.intensity = 3f;
+        orbLight.range = 10f;
+    }
+
+    private void SetupCollider()
+    {
+        SphereCollider collider = GetComponent<SphereCollider>();
+        if (collider == null)
+            collider = gameObject.AddComponent<SphereCollider>();
+
+        collider.radius = 1.5f; // 기존 2f에서 3f로 증가
+        collider.isTrigger = true;
+    }
+
+    private void StartBehavior()
+    {
+        StartCoroutine(MovementRoutine());
+        StartCoroutine(AttackRoutine());
+    }
+
+    private IEnumerator MovementRoutine()
+    {
+        while (!isDestroyed)
+        {
+            // 일정 시간마다 새로운 랜덤 위치 설정
+            if (Time.time - lastRandomMoveTime >= randomMoveInterval)
+            {
+                SetRandomTargetPosition();
+                lastRandomMoveTime = Time.time;
+            }
+
+            // 목표 위치로 이동 (공격 중일 때 느리게)
+            Vector3 currentPos = transform.position;
+            Vector3 targetPos = new Vector3(currentTargetPosition.x, heightFixed, currentTargetPosition.z);
+            Vector3 moveDirection = (targetPos - currentPos).normalized;
+
+            if (moveDirection != Vector3.zero)
+            {
+                float currentMoveSpeed = isFiring ? moveSpeed * 0.3f : moveSpeed;
+                Vector3 newPosition = currentPos + moveDirection * currentMoveSpeed * Time.deltaTime;
+                newPosition.y = heightFixed;
+                transform.position = newPosition;
+            }
+
+            // 플레이어를 향해 회전
+            if (player != null)
+            {
+                Vector3 lookDirection = (player.position - transform.position).normalized;
+                lookDirection.y = 0;
+                if (lookDirection != Vector3.zero)
+                {
+                    transform.rotation = Quaternion.Slerp(transform.rotation,
+                        Quaternion.LookRotation(lookDirection), Time.deltaTime * 2f);
+                }
+            }
+
+            // 추가 회전 (구체 특성)
+            transform.Rotate(Vector3.up, 30f * Time.deltaTime);
+
+            yield return null;
+        }
+    }
+
+    private void SetRandomTargetPosition()
+    {
+        if (player == null) return;
+
+        float randomAngle = Random.Range(0f, 360f);
+        float randomDistance = Random.Range(minDistanceToPlayer, maxDistanceToPlayer);
+
+        Vector3 randomOffset = new Vector3(
+            Mathf.Cos(randomAngle * Mathf.Deg2Rad) * randomDistance,
+            0,
+            Mathf.Sin(randomAngle * Mathf.Deg2Rad) * randomDistance
+        );
+
+        currentTargetPosition = player.position + randomOffset;
+    }
+
+    private IEnumerator AttackRoutine()
+    {
+        while (!isDestroyed && player != null)
+        {
+            if (Time.time - lastBulletTime >= darkBulletCooldown)
+            {
+                yield return StartCoroutine(PerformBulletAttack());
+                lastBulletTime = Time.time;
+            }
+            yield return new WaitForSeconds(0.1f);
+        }
+    }
+
+    private IEnumerator PerformBulletAttack()
+    {
+        isFiring = true;
+        Debug.Log("어둠 구체 다크 불릿 공격 시작!");
+
+        // 차징 준비 시간
+        yield return new WaitForSeconds(1f);
+
+        // 다크 불릿 발사
+        FireBulletPattern();
+
+        // 다크 불릿 발사 완료
+        isFiring = false;
+    }
+
+    private void FireBulletPattern()
+    {
+        Debug.Log("어둠의 다크 불릿 발사!");
+
+        // 원형 다크 불릿 패턴
+        float angleStep = 360f / darkBulletCount;
+
+        for (int i = 0; i < darkBulletCount; i++)
+        {
+            float angle = i * angleStep;
+            Vector3 direction = new Vector3(
+                Mathf.Cos(angle * Mathf.Deg2Rad),
+                0,
+                Mathf.Sin(angle * Mathf.Deg2Rad)
+            );
+
+            CreateBullet(direction, darkBulletDamage, darkBulletSpeed);
+        }
+
+        // 추가 패턴: 플레이어 방향 집중 다크 불릿
+        StartCoroutine(FireTargetedBullets());
+    }
+
+    private void CreateBullet(Vector3 direction, float damage, float speed)
+    {
+        if (darkBulletPrefab != null)
+        {
+            GameObject bullet = Instantiate(darkBulletPrefab, transform.position,
+                Quaternion.LookRotation(direction));
+
+            // 불릿 스크립트가 있다면 초기화
+            Enemy_Final_Boss_Bullet bulletScript = bullet.GetComponent<Enemy_Final_Boss_Bullet>();
+            if (bulletScript != null)
+            {
+                bulletScript.Initialize(damage, direction * speed);
+            }
+            else
+            {
+                // 기본 Rigidbody 이동
+                Rigidbody bulletRb = bullet.GetComponent<Rigidbody>();
+                if (bulletRb != null)
+                {
+                    bulletRb.velocity = direction * speed;
+                }
+            }
+
+            Destroy(bullet, 5f);
+        }
+        
+    }
+
+    private void CreateTempBullet(Vector3 direction, float damage, float speed)
+    {
+        GameObject tempBullet = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        tempBullet.name = "TempDarkBullet";
+        tempBullet.transform.position = transform.position;
+        tempBullet.transform.localScale = Vector3.one * 0.5f;
+
+        // 어둠의 보라색
+        Renderer renderer = tempBullet.GetComponent<Renderer>();
+        Material material = new Material(Shader.Find("Standard"));
+        material.color = new Color(0.5f, 0f, 0.5f);
+        material.EnableKeyword("_EMISSION");
+        material.SetColor("_EmissionColor", Color.magenta);
+        renderer.material = material;
+
+        Rigidbody rb = tempBullet.GetComponent<Rigidbody>();
+        rb.useGravity = false;
+        rb.velocity = direction * speed;
+
+        // 데미지 처리
+        Collider collider = tempBullet.GetComponent<Collider>();
+        collider.isTrigger = true;
+
+        Enemy_Temp_Damage_Projectile damageScript = tempBullet.AddComponent<Enemy_Temp_Damage_Projectile>();
+        damageScript.Initialize(damage, "어둠 다크불릿");
+
+        Destroy(tempBullet, 5f);
+    }
+
+    private IEnumerator FireTargetedBullets()
+    {
+        yield return new WaitForSeconds(0.5f);
+
+        if (player == null) yield break;
+
+        // 플레이어 방향으로 집중 다크 불릿 (3발)
+        for (int i = 0; i < 3; i++)
+        {
+            Vector3 baseDirection = (player.position - transform.position).normalized;
+            baseDirection.y = 0;
+
+            // 약간의 각도 변화
+            float angleOffset = (i - 1) * 20f;
+            Quaternion rotation = Quaternion.AngleAxis(angleOffset, Vector3.up);
+            Vector3 direction = rotation * baseDirection;
+
+            CreateBullet(direction, darkBulletDamage * 1.2f, darkBulletSpeed * 1.3f);
+
+            yield return new WaitForSeconds(0.2f);
+        }
+    }
+
+    public void TakeDamage(float damage)
+    {
+        if (isDestroyed) return;
+
+        health -= damage;
+        Debug.Log($"어둠 구체 피해: {damage}, 남은 체력: {health}");
+
+        StartCoroutine(HitEffect());
+
+        if (health <= 0)
+        {
+            DestroyOrb();
+        }
+    }
+
+    private IEnumerator HitEffect()
+    {
+        Renderer renderer = GetComponentInChildren<Renderer>();
+        if (renderer != null)
+        {
+            Color originalColor = renderer.material.color;
+            renderer.material.color = Color.white;
+            yield return new WaitForSeconds(0.1f);
+            renderer.material.color = originalColor;
+        }
+    }
+
+    private void DestroyOrb()
+    {
+        if (isDestroyed) return;
+
+        isDestroyed = true;
+        Debug.Log("어둠 구체 파괴됨!");
+
+        // 보스에게 알림
+        if (ownerBoss != null)
+            ownerBoss.OnDarkOrbDestroyed();
+
+        // 마지막 다크 불릿 폭발
+        StartCoroutine(DeathBulletExplosion());
+
+        Destroy(gameObject, 1f);
+    }
+
+    private IEnumerator DeathBulletExplosion()
+    {
+        float angleStep = 360f / (darkBulletCount * 2);
+
+        for (int i = 0; i < darkBulletCount * 2; i++)
+        {
+            float angle = i * angleStep;
+            Vector3 direction = new Vector3(
+                Mathf.Cos(angle * Mathf.Deg2Rad),
+                0,
+                Mathf.Sin(angle * Mathf.Deg2Rad)
+            );
+
+            CreateBullet(direction, darkBulletDamage * 0.7f, darkBulletSpeed * 1.5f);
+        }
+
+        yield return null;
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        // 다양한 플레이어 공격 태그 확인
+        if (other.CompareTag("Attack")) 
+        {
+            TakeDamage(50f);
+        }
+    }
+
+    private void Update()
+    {
+        // Y축 위치 강제 고정
+        if (transform.position.y != heightFixed)
+        {
+            Vector3 pos = transform.position;
+            pos.y = heightFixed;
+            transform.position = pos;
+        }
+
+        // 플레이어와의 거리 체크
+        if (player != null)
+        {
+            float distanceToPlayer = Vector3.Distance(transform.position, player.position);
+
+            if (distanceToPlayer < minDistanceToPlayer)
+            {
+                Vector3 awayDirection = (transform.position - player.position).normalized;
+                awayDirection.y = 0;
+                transform.position += awayDirection * moveSpeed * Time.deltaTime;
+            }
+            else if (distanceToPlayer > maxDistanceToPlayer)
+            {
+                Vector3 towardsDirection = (player.position - transform.position).normalized;
+                towardsDirection.y = 0;
+                transform.position += towardsDirection * moveSpeed * Time.deltaTime;
+            }
+        }
+    }
+
+    // 에디터에서 콜라이더 영역 시각화
+    private void OnDrawGizmosSelected()
+    {
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireSphere(transform.position, 3f); // Trigger 콜라이더
+
+        Gizmos.color = Color.yellow;
+        Gizmos.DrawWireSphere(transform.position, 2.5f); // Solid 콜라이더
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_DarkOrb.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_DarkOrb.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8560a3f9318c3c24393bcfb1d67accd4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_LightPillar.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_LightPillar.cs
@@ -1,0 +1,141 @@
+using System.Collections;
+using UnityEngine;
+
+/// <summary>
+/// 최종보스 빛 모드 - 빛 기둥 공격
+/// </summary>
+public class Enemy_Final_Boss_LightPillar : MonoBehaviour
+{
+    [Header("빛 기둥 설정")]
+    [SerializeField] private float pillarRadius = 4f;
+    [SerializeField] private float pillarHeight = 20f;
+
+    [Header("공격 설정")]
+    [SerializeField] private float warningDuration = 1.5f;
+    [SerializeField] private float activeDuration = 2f;
+
+    [Header("이펙트")]
+    [SerializeField] private GameObject warningEffect;
+    [SerializeField] private GameObject pillarEffect;
+    [SerializeField] private Light pillarLight;
+
+    private float damage;
+    private bool isActive = false;
+    private AudioSource audioSource;
+    private CapsuleCollider damageCollider;
+
+    private void Awake()
+    {
+        // 컴포넌트 초기화
+        audioSource = GetComponent<AudioSource>();
+        damageCollider = GetComponent<CapsuleCollider>();
+
+        // 콜라이더 초기 설정
+        if (damageCollider == null)
+            damageCollider = gameObject.AddComponent<CapsuleCollider>();
+
+        damageCollider.isTrigger = true;
+        damageCollider.radius = pillarRadius;
+        damageCollider.height = pillarHeight;
+        damageCollider.center = new Vector3(0, pillarHeight * 0.5f, 0);
+        damageCollider.enabled = false;
+
+        // 조명 설정
+        if (pillarLight == null)
+            pillarLight = gameObject.AddComponent<Light>();
+
+        pillarLight.type = LightType.Point;
+        pillarLight.color = Color.white;
+        pillarLight.intensity = 0f;
+        pillarLight.range = pillarRadius * 2f;
+    }
+
+    public void StartLightPillar(float pillarDamage, float duration = 3.5f)
+    {
+        damage = pillarDamage;
+        warningDuration = duration * 0.4f; // 40%는 경고 시간
+        activeDuration = duration * 0.6f;  // 60%는 활성화 시간
+
+        StartCoroutine(PillarSequence());
+    }
+
+    private IEnumerator PillarSequence()
+    {
+        // 1단계: 경고
+        if (warningEffect != null)
+            warningEffect.SetActive(true);
+
+        // 경고 깜빡임 효과
+        StartCoroutine(BlinkWarning());
+
+        yield return new WaitForSeconds(warningDuration);
+
+        // 2단계: 활성화
+        if (warningEffect != null)
+            warningEffect.SetActive(false);
+
+        if (pillarEffect != null)
+            pillarEffect.SetActive(true);
+
+        // 데미지 콜라이더 활성화
+        damageCollider.enabled = true;
+        isActive = true;
+
+        // 조명 강화
+        if (pillarLight != null)
+        {
+            pillarLight.intensity = 10f;
+        }
+
+        yield return new WaitForSeconds(activeDuration);
+
+        // 3단계: 종료 및 소멸
+        isActive = false;
+        Destroy(gameObject);
+    }
+
+    private IEnumerator BlinkWarning()
+    {
+        float blinkTime = 0f;
+
+        while (blinkTime < warningDuration)
+        {
+            if (pillarLight != null)
+            {
+                // 빨간색으로 깜빡임
+                bool visible = Mathf.Sin(Time.time * 10f) > 0;
+                pillarLight.intensity = visible ? 3f : 0f;
+                pillarLight.color = Color.red;
+            }
+
+            blinkTime += Time.deltaTime;
+            yield return null;
+        }
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (isActive && other.CompareTag("Player"))
+        {
+            Player.Player playerComponent = other.GetComponent<Player.Player>();
+            if (playerComponent != null)
+            {
+                playerComponent.DecreaseHP(damage);
+            }
+        }
+    }
+
+    private void OnTriggerStay(Collider other)
+    {
+        // 지속 데미지는 Enemy_Temp_Damage_Projectile에서 처리
+        if (isActive && other.CompareTag("Player"))
+        {
+            Enemy_Temp_Damage_Projectile damageScript = GetComponent<Enemy_Temp_Damage_Projectile>();
+            if (damageScript == null)
+            {
+                damageScript = gameObject.AddComponent<Enemy_Temp_Damage_Projectile>();
+                damageScript.Initialize(damage * 0.3f, "빛 기둥", true); // 초당 30% 데미지
+            }
+        }
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_LightPillar.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_LightPillar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8fc83a2c14f81f047b0de37b97919028
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_Light_Orb.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_Light_Orb.cs
@@ -1,0 +1,473 @@
+using UnityEngine;
+using System.Collections;
+
+/// <summary>
+/// 최종보스의 빛 구체 - 레일건 공격 (프리팹 자체 관리)
+/// </summary>
+public class Enemy_Final_Boss_LightOrb : MonoBehaviour
+{
+    [Header("구체 설정")]
+    [SerializeField] private float health = 100f;
+    [SerializeField] private float moveSpeed = 3f;
+    [SerializeField] private float heightFixed = 3f;
+    [SerializeField] private float minDistanceToPlayer = 8f;
+    [SerializeField] private float maxDistanceToPlayer = 18f;
+    [SerializeField] private float randomMoveInterval = 3f;
+
+    [Header("레일건 공격")]
+    [SerializeField] private GameObject railgunBeamPrefab;  // 자체 관리
+    [SerializeField] private float railgunDamage = 120f;
+    [SerializeField] private float railgunChargeTime = 2f;
+    [SerializeField] private float railgunCooldown = 4f;
+
+    [Header("시각적 효과")]
+    [SerializeField] private Material orbMaterial;
+    [SerializeField] private Color orbColor = Color.white;
+    [SerializeField] private float emissionIntensity = 0.5f;
+    [SerializeField] private GameObject chargingEffect;  // 차징 이펙트
+
+    private Enemy_Final_Boss_Neutral ownerBoss;
+    private Transform player;
+    private Vector3 currentTargetPosition;
+    private float lastRandomMoveTime;
+    private float lastRailgunTime;
+    private bool isCharging = false;
+    private bool isDestroyed = false;
+    private GameObject currentChargingEffect;
+
+    // 초기화 간소화 - 보스 참조와 기본 설정만
+    public void Initialize(Enemy_Final_Boss_Neutral boss)
+    {
+        ownerBoss = boss;
+        SetupComponents();
+        StartBehavior();
+    }
+
+    // 런타임에서 설정 변경 가능한 메서드들
+    public void SetHealth(float newHealth) => health = newHealth;
+    public void SetMoveSpeed(float newSpeed) => moveSpeed = newSpeed;
+    public void SetRailgunSettings(float damage, float chargeTime, float cooldown)
+    {
+        railgunDamage = damage;
+        railgunChargeTime = chargeTime;
+        railgunCooldown = cooldown;
+    }
+
+    private void SetupComponents()
+    {
+        // 플레이어 찾기
+        player = GameObject.FindGameObjectWithTag("Player")?.transform;
+
+        // 초기 위치 설정
+        SetRandomTargetPosition();
+        transform.position = new Vector3(currentTargetPosition.x, heightFixed, currentTargetPosition.z);
+
+        // 리지드바디 설정
+        SetupRigidbody();
+
+        // 렌더러 설정
+        SetupRenderer();
+
+        // 조명 설정
+        SetupLight();
+
+        // 콜라이더 설정
+        SetupCollider();
+    }
+
+    private void SetupRigidbody()
+    {
+        Rigidbody rb = GetComponent<Rigidbody>();
+        if (rb == null)
+            rb = gameObject.AddComponent<Rigidbody>();
+
+        rb.useGravity = false;
+        rb.constraints = RigidbodyConstraints.FreezeRotationX |
+                        RigidbodyConstraints.FreezeRotationZ |
+                        RigidbodyConstraints.FreezePositionY;
+    }
+
+    private void SetupRenderer()
+    {
+        Renderer renderer = GetComponent<Renderer>();
+        if (renderer == null)
+        {
+            // 기본 구체 생성
+            GameObject sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            sphere.transform.SetParent(transform);
+            sphere.transform.localPosition = Vector3.zero;
+            sphere.transform.localScale = Vector3.one * 2f;
+            renderer = sphere.GetComponent<Renderer>();
+        }
+
+        // 머티리얼 설정
+        if (orbMaterial != null)
+        {
+            renderer.material = orbMaterial;
+        }
+        else
+        {
+            Material material = new Material(Shader.Find("Standard"));
+            material.color = orbColor;
+            material.EnableKeyword("_EMISSION");
+            material.SetColor("_EmissionColor", orbColor * emissionIntensity);
+            renderer.material = material;
+        }
+    }
+
+    private void SetupLight()
+    {
+        Light orbLight = GetComponent<Light>();
+        if (orbLight == null)
+            orbLight = gameObject.AddComponent<Light>();
+
+        orbLight.type = LightType.Point;
+        orbLight.color = orbColor;
+        orbLight.intensity = 4f;
+        orbLight.range = 12f;
+    }
+
+    private void SetupCollider()
+    {
+        SphereCollider collider = GetComponent<SphereCollider>();
+        if (collider == null)
+            collider = gameObject.AddComponent<SphereCollider>();
+
+        collider.radius = 1.5f; // 기존 2f에서 3f로 증가
+        collider.isTrigger = true;
+
+        // 추가 콜라이더 (일반 충돌용)
+        SphereCollider solidCollider = gameObject.AddComponent<SphereCollider>();
+        solidCollider.radius = 1.5f;
+        solidCollider.isTrigger = false; // 일반 충돌
+    }
+
+    private void StartBehavior()
+    {
+        StartCoroutine(MovementRoutine());
+        StartCoroutine(AttackRoutine());
+    }
+
+    private IEnumerator MovementRoutine()
+    {
+        while (!isDestroyed)
+        {
+            // 일정 시간마다 새로운 랜덤 위치 설정
+            if (Time.time - lastRandomMoveTime >= randomMoveInterval)
+            {
+                SetRandomTargetPosition();
+                lastRandomMoveTime = Time.time;
+            }
+
+            // 목표 위치로 이동 (차징 중일 않을 때만)
+            if (!isCharging)
+            {
+                Vector3 currentPos = transform.position;
+                Vector3 targetPos = new Vector3(currentTargetPosition.x, heightFixed, currentTargetPosition.z);
+                Vector3 moveDirection = (targetPos - currentPos).normalized;
+
+                if (moveDirection != Vector3.zero)
+                {
+                    Vector3 newPosition = currentPos + moveDirection * moveSpeed * Time.deltaTime;
+                    newPosition.y = heightFixed;
+                    transform.position = newPosition;
+                }
+
+                // 플레이어를 향해 회전
+                if (player != null)
+                {
+                    Vector3 lookDirection = (player.position - transform.position).normalized;
+                    lookDirection.y = 0;
+                    if (lookDirection != Vector3.zero)
+                    {
+                        transform.rotation = Quaternion.Slerp(transform.rotation,
+                            Quaternion.LookRotation(lookDirection), Time.deltaTime * 3f);
+                    }
+                }
+            }
+
+            // 부드러운 자전
+            transform.Rotate(Vector3.up, 20f * Time.deltaTime);
+
+            yield return null;
+        }
+    }
+
+    private void SetRandomTargetPosition()
+    {
+        if (player == null) return;
+
+        float randomAngle = Random.Range(0f, 360f);
+        float randomDistance = Random.Range(minDistanceToPlayer, maxDistanceToPlayer);
+
+        Vector3 randomOffset = new Vector3(
+            Mathf.Cos(randomAngle * Mathf.Deg2Rad) * randomDistance,
+            0,
+            Mathf.Sin(randomAngle * Mathf.Deg2Rad) * randomDistance
+        );
+
+        currentTargetPosition = player.position + randomOffset;
+    }
+
+    private IEnumerator AttackRoutine()
+    {
+        while (!isDestroyed && player != null)
+        {
+            if (Time.time - lastRailgunTime >= railgunCooldown)
+            {
+                yield return StartCoroutine(PerformRailgunAttack());
+                lastRailgunTime = Time.time;
+            }
+            yield return new WaitForSeconds(0.1f);
+        }
+    }
+
+    private IEnumerator PerformRailgunAttack()
+    {
+        isCharging = true;
+        Debug.Log("빛 구체 레일건 차징 시작!");
+
+        // 차징 이펙트 시작
+        StartChargingEffect();
+
+        // 차징 시간
+        yield return new WaitForSeconds(railgunChargeTime);
+
+        // 레일건 발사
+        if (player != null)
+        {
+            Vector3 direction = (player.position - transform.position).normalized;
+            direction.y = 0;
+
+            FireRailgun(direction);
+            Debug.Log("빛 구체 레일건 발사!");
+        }
+
+        // 차징 이펙트 종료
+        StopChargingEffect();
+        isCharging = false;
+    }
+
+    private void StartChargingEffect()
+    {
+        if (chargingEffect != null)
+        {
+            currentChargingEffect = Instantiate(chargingEffect, transform.position, transform.rotation);
+            currentChargingEffect.transform.SetParent(transform);
+        }
+        else
+        {
+            // 임시 차징 이펙트
+            CreateTempChargingEffect();
+        }
+    }
+
+    private void CreateTempChargingEffect()
+    {
+        currentChargingEffect = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        currentChargingEffect.name = "ChargingEffect";
+        currentChargingEffect.transform.SetParent(transform);
+        currentChargingEffect.transform.localPosition = Vector3.zero;
+        currentChargingEffect.transform.localScale = Vector3.one * 3f;
+
+        Renderer renderer = currentChargingEffect.GetComponent<Renderer>();
+        Material material = new Material(Shader.Find("Standard"));
+        material.color = new Color(1f, 1f, 1f, 0.3f);
+        material.EnableKeyword("_EMISSION");
+        material.SetColor("_EmissionColor", Color.cyan * 2f);
+        renderer.material = material;
+
+        // 투명하게
+        material.renderQueue = 3000;
+        material.SetFloat("_Mode", 3);
+        material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+        material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+        material.SetInt("_ZWrite", 0);
+        material.DisableKeyword("_ALPHATEST_ON");
+        material.EnableKeyword("_ALPHABLEND_ON");
+
+        // 콜라이더 제거
+        DestroyImmediate(currentChargingEffect.GetComponent<Collider>());
+
+        // 펄스 효과
+        StartCoroutine(ChargingPulseEffect());
+    }
+
+    private IEnumerator ChargingPulseEffect()
+    {
+        while (currentChargingEffect != null && isCharging)
+        {
+            float scale = 3f + Mathf.Sin(Time.time * 10f) * 0.5f;
+            currentChargingEffect.transform.localScale = Vector3.one * scale;
+            yield return null;
+        }
+    }
+
+    private void StopChargingEffect()
+    {
+        if (currentChargingEffect != null)
+        {
+            Destroy(currentChargingEffect);
+            currentChargingEffect = null;
+        }
+    }
+
+    private void FireRailgun(Vector3 direction)
+    {
+        if (railgunBeamPrefab != null)
+        {
+            GameObject beam = Instantiate(railgunBeamPrefab, transform.position,
+                Quaternion.LookRotation(direction));
+
+            Enemy_Final_Boss_RailgunBeam beamScript = beam.GetComponent<Enemy_Final_Boss_RailgunBeam>();
+            if (beamScript != null)
+            {
+                beamScript.Initialize(railgunDamage, direction, 30f);
+            }
+        }
+        else
+        {
+            // 임시 레일건 빔 생성
+            CreateTempRailgunBeam(direction);
+        }
+    }
+
+    private void CreateTempRailgunBeam(Vector3 direction)
+    {
+        GameObject tempBeam = new GameObject("TempRailgunBeam");
+        tempBeam.transform.position = transform.position;
+        tempBeam.transform.rotation = Quaternion.LookRotation(direction);
+
+        // 빔 시각적 표현
+        LineRenderer lineRenderer = tempBeam.AddComponent<LineRenderer>();
+        lineRenderer.material = new Material(Shader.Find("Sprites/Default"));
+        lineRenderer.startColor = Color.cyan;
+        lineRenderer.endColor = Color.white;
+        lineRenderer.startWidth = 0.5f;
+        lineRenderer.endWidth = 0.1f;
+        lineRenderer.positionCount = 2;
+        lineRenderer.useWorldSpace = true;
+
+        Vector3 startPos = transform.position;
+        Vector3 endPos = startPos + direction * 30f;
+
+        lineRenderer.SetPosition(0, startPos);
+        lineRenderer.SetPosition(1, endPos);
+
+        // 데미지 처리를 위한 스크립트 추가
+        Enemy_Final_Boss_RailgunBeam beamScript = tempBeam.AddComponent<Enemy_Final_Boss_RailgunBeam>();
+        beamScript.Initialize(railgunDamage, direction, 30f);
+
+        Destroy(tempBeam, 2f);
+    }
+
+    public void TakeDamage(float damage)
+    {
+        if (isDestroyed) return;
+
+        health -= damage;
+        Debug.Log($"빛 구체 피해: {damage}, 남은 체력: {health}");
+
+        StartCoroutine(HitEffect());
+
+        if (health <= 0)
+        {
+            DestroyOrb();
+        }
+    }
+
+    private IEnumerator HitEffect()
+    {
+        Renderer renderer = GetComponentInChildren<Renderer>();
+        if (renderer != null)
+        {
+            Color originalColor = renderer.material.color;
+            renderer.material.color = Color.red;
+            yield return new WaitForSeconds(0.1f);
+            renderer.material.color = originalColor;
+        }
+    }
+
+    private void DestroyOrb()
+    {
+        if (isDestroyed) return;
+
+        isDestroyed = true;
+        Debug.Log("빛 구체 파괴됨!");
+
+        // 차징 이펙트 정리
+        StopChargingEffect();
+
+        // 보스에게 알림
+        if (ownerBoss != null)
+            ownerBoss.OnLightOrbDestroyed();
+
+        // 마지막 폭발 레일건
+        StartCoroutine(DeathRailgunExplosion());
+
+        Destroy(gameObject, 1f);
+    }
+
+    private IEnumerator DeathRailgunExplosion()
+    {
+        // 8방향으로 레일건 발사
+        for (int i = 0; i < 8; i++)
+        {
+            float angle = i * 45f;
+            Vector3 direction = new Vector3(
+                Mathf.Cos(angle * Mathf.Deg2Rad),
+                0,
+                Mathf.Sin(angle * Mathf.Deg2Rad)
+            );
+
+            FireRailgun(direction);
+
+            // 약간의 딜레이
+            yield return new WaitForSeconds(0.1f);
+        }
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        // 다양한 플레이어 공격 태그 확인
+        if (other.CompareTag("Attack") )
+        {
+            Debug.Log($"빛 구체가 {other.name} (태그: {other.tag})에 맞음!");
+            TakeDamage(50f);
+        }
+        
+    }
+
+ 
+    private void Update()
+    {
+        // Y축 위치 강제 고정
+        if (transform.position.y != heightFixed)
+        {
+            Vector3 pos = transform.position;
+            pos.y = heightFixed;
+            transform.position = pos;
+        }
+
+        // 플레이어와의 거리 체크 (차징 중이 아닐 때만)
+        if (player != null && !isCharging)
+        {
+            float distanceToPlayer = Vector3.Distance(transform.position, player.position);
+
+            if (distanceToPlayer < minDistanceToPlayer)
+            {
+                Vector3 awayDirection = (transform.position - player.position).normalized;
+                awayDirection.y = 0;
+                transform.position += awayDirection * moveSpeed * Time.deltaTime * 0.5f;
+            }
+            else if (distanceToPlayer > maxDistanceToPlayer)
+            {
+                Vector3 towardsDirection = (player.position - transform.position).normalized;
+                towardsDirection.y = 0;
+                transform.position += towardsDirection * moveSpeed * Time.deltaTime * 0.5f;
+            }
+        }
+    }
+
+
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_Light_Orb.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_Light_Orb.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f7057318f64b9641948ac0c92e61b3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_PullBullet.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_PullBullet.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+namespace Enemy
+{
+    public class Enemy_Final_Boss_PullBullet : MonoBehaviour
+    {
+        private Vector3 moveDirection;
+        private float speed;
+        private float lifeTime;
+        private Vector3 targetPosition;
+
+        // 초기화 메서드: 방향, 속도, 생존 시간, 당기는 위치(보스 쪽)
+        public void Initialize(Vector3 direction, float speed, float lifeTime, Vector3 targetPosition)
+        {
+            this.moveDirection = direction.normalized;
+            this.speed = speed;
+            this.lifeTime = lifeTime;
+            this.targetPosition = targetPosition;
+
+            Destroy(gameObject, lifeTime);  // 일정 시간 후 자동 삭제
+        }
+
+        private void Update()
+        {
+            transform.position += moveDirection * speed * Time.deltaTime;
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (other.CompareTag("Player"))
+            {
+                Rigidbody playerRb = other.GetComponent<Rigidbody>();
+                if (playerRb != null)
+                {
+                    // 보스 쪽으로 당기기
+                    Vector3 pullDir = (targetPosition - other.transform.position).normalized;
+                    playerRb.AddForce(pullDir * 10f, ForceMode.Impulse);
+                }
+
+                Destroy(gameObject); // 충돌 후 소멸
+            }
+        }
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_PullBullet.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_PullBullet.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 11f91ddafa7caf0468da0b0294700abf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_RailgunBeam.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_RailgunBeam.cs
@@ -1,0 +1,394 @@
+using UnityEngine;
+using Enemy;
+using System.Collections;
+
+/// <summary>
+/// 라이트오브에서 발사하는 5갈래 레일건 빔 (중간보스 스타일)
+/// </summary>
+public class Enemy_Final_Boss_RailgunBeam : MonoBehaviour
+{
+    [Header("레일건 설정")]
+    [SerializeField] private float damage = 120f;
+    [SerializeField] private float maxRange = 30f;
+    [SerializeField] private float beamWidth = 0.5f;
+    [SerializeField] private float chargingTime = 0.5f;
+    [SerializeField] private float beamDuration = 1f;
+    [SerializeField] private DamageType damageType = DamageType.Magical;
+    [SerializeField] private ElementType elementType = ElementType.Light;
+    [SerializeField] private bool canPenetrate = false;
+
+    [Header("5갈래 설정")]
+    [SerializeField] private float[] beamAngles = { 0f, -15f, 15f, -30f, 30f }; // 중앙, 좌15, 우15, 좌30, 우30
+
+    [Header("컴포넌트")]
+    [SerializeField] private LineRenderer centerBeam;
+    [SerializeField] private LineRenderer leftBeam1;
+    [SerializeField] private LineRenderer rightBeam1;
+    [SerializeField] private LineRenderer leftBeam2;
+    [SerializeField] private LineRenderer rightBeam2;
+    [SerializeField] private ParticleSystem chargingParticle;
+
+    [Header("사운드")]
+    [SerializeField] private AudioClip fireSound;
+
+    private AudioSource audioSource;
+    private Vector3 direction;
+    private bool isFiring = false;
+    private LineRenderer[] allBeams;
+
+    public void Initialize(float beamDamage, Vector3 beamDirection, float beamRange)
+    {
+        damage = beamDamage;
+        direction = beamDirection.normalized;
+        maxRange = beamRange;
+
+        SetupComponents();
+        StartCoroutine(FireSequence());
+    }
+
+    private void SetupComponents()
+    {
+        // LineRenderer 배열 설정
+        allBeams = new LineRenderer[5];
+        allBeams[0] = centerBeam;
+        allBeams[1] = leftBeam1;
+        allBeams[2] = rightBeam1;
+        allBeams[3] = leftBeam2;
+        allBeams[4] = rightBeam2;
+
+        // 자동 생성 및 설정
+        SetupAllBeams();
+
+        // AudioSource 설정
+        audioSource = GetComponent<AudioSource>();
+        if (audioSource == null)
+        {
+            audioSource = gameObject.AddComponent<AudioSource>();
+        }
+
+        // ParticleSystem 설정
+        if (chargingParticle != null)
+        {
+            SetupChargingParticle();
+        }
+    }
+
+    private void SetupAllBeams()
+    {
+        for (int i = 0; i < allBeams.Length; i++)
+        {
+            if (allBeams[i] == null)
+            {
+                // 새로운 LineRenderer 생성
+                GameObject beamObj = new GameObject($"Beam_{i}");
+                beamObj.transform.SetParent(transform);
+                beamObj.transform.localPosition = Vector3.zero;
+                allBeams[i] = beamObj.AddComponent<LineRenderer>();
+            }
+
+            SetupSingleBeam(allBeams[i], i);
+        }
+    }
+
+    private void SetupSingleBeam(LineRenderer beam, int index)
+    {
+        if (beam == null) return;
+
+        // 빔 기본 설정
+        beam.startWidth = 0f;
+        beam.endWidth = 0f;
+        beam.enabled = false;
+        beam.useWorldSpace = true;
+        beam.positionCount = 2;
+
+        // 빔 두께 (중앙이 가장 두껍고 바깥쪽이 얇음)
+        float widthMultiplier = index == 0 ? 1f : 0.7f; // 중앙빔이 가장 두껍게
+        beam.startWidth = beamWidth * widthMultiplier;
+        beam.endWidth = beamWidth * widthMultiplier * 0.5f;
+
+        // 빔 색상 설정 (중앙이 가장 밝고 바깥쪽이 어둡게)
+        Gradient gradient = new Gradient();
+        Color beamColor = index == 0 ? Color.white : Color.cyan;
+        float alpha = index == 0 ? 1f : 0.8f - (index * 0.1f);
+
+        gradient.SetKeys(
+            new GradientColorKey[] {
+                new GradientColorKey(beamColor, 0.0f),
+                new GradientColorKey(Color.cyan, 1.0f)
+            },
+            new GradientAlphaKey[] {
+                new GradientAlphaKey(alpha, 0.0f),
+                new GradientAlphaKey(alpha * 0.3f, 1.0f)
+            }
+        );
+        beam.colorGradient = gradient;
+
+        // 머티리얼 설정
+        if (beam.material == null)
+        {
+            beam.material = new Material(Shader.Find("Sprites/Default"));
+        }
+
+        // 빔 스타일링
+        beam.textureMode = LineTextureMode.Stretch;
+        beam.alignment = LineAlignment.View;
+        beam.numCapVertices = 8;
+        beam.numCornerVertices = 8;
+    }
+
+    private void SetupChargingParticle()
+    {
+        chargingParticle.Stop();
+        var main = chargingParticle.main;
+        main.playOnAwake = false;
+        main.startColor = Color.cyan;
+        main.startSize = 2f; // 5갈래라서 더 크게
+        main.startLifetime = chargingTime;
+    }
+
+    private IEnumerator FireSequence()
+    {
+        isFiring = true;
+
+        // 1. 차징 단계
+        yield return StartCoroutine(ChargingPhase());
+
+        // 2. 발사 단계
+        yield return StartCoroutine(FiringPhase());
+
+        // 3. 정리
+        CleanupEffects();
+        Destroy(gameObject);
+    }
+
+    private IEnumerator ChargingPhase()
+    {
+        Debug.Log("5갈래 레일건 차징 시작!");
+
+        // 차징 파티클 시작
+        if (chargingParticle != null)
+        {
+            chargingParticle.transform.position = transform.position;
+            chargingParticle.Play();
+        }
+
+        // 차징 중 빔들을 점진적으로 표시
+        float elapsed = 0f;
+        while (elapsed < chargingTime)
+        {
+            elapsed += Time.deltaTime;
+            float progress = elapsed / chargingTime;
+
+            // 차징 중 얇은 빔들을 점진적으로 표시
+            for (int i = 0; i < allBeams.Length; i++)
+            {
+                if (allBeams[i] != null)
+                {
+                    allBeams[i].enabled = true;
+                    float chargingWidth = (beamWidth * 0.1f) * progress;
+                    allBeams[i].startWidth = chargingWidth;
+                    allBeams[i].endWidth = chargingWidth * 0.5f;
+
+                    // 빔 위치 설정
+                    Vector3 beamDirection = RotateDirection(direction, beamAngles[i]);
+                    Vector3 startPos = transform.position;
+                    Vector3 endPos = startPos + beamDirection * maxRange;
+
+                    allBeams[i].SetPosition(0, startPos);
+                    allBeams[i].SetPosition(1, endPos);
+                }
+            }
+
+            yield return null;
+        }
+
+        // 차징 완료 - 파티클 정지
+        if (chargingParticle != null)
+        {
+            chargingParticle.Stop();
+        }
+    }
+
+    private IEnumerator FiringPhase()
+    {
+        Debug.Log("5갈래 레일건 발사!");
+
+        // 사운드 재생
+        PlayFireSound();
+
+        // 5갈래 빔 동시 발사
+        Fire5BeamRailgun();
+
+        // 빔 지속 시간
+        yield return new WaitForSeconds(beamDuration);
+    }
+
+    private void Fire5BeamRailgun()
+    {
+        Vector3 startPos = transform.position;
+
+        // 5방향 계산 및 발사
+        for (int i = 0; i < beamAngles.Length; i++)
+        {
+            Vector3 beamDirection = RotateDirection(direction, beamAngles[i]);
+            FireSingleBeam(startPos, beamDirection, allBeams[i], i);
+        }
+    }
+
+    private void FireSingleBeam(Vector3 startPos, Vector3 beamDirection, LineRenderer beam, int beamIndex)
+    {
+        Vector3 endPos = startPos + beamDirection * maxRange;
+        bool hitPlayer = false;
+
+        // 레이캐스트로 충돌 검사
+        RaycastHit[] hits = Physics.RaycastAll(startPos, beamDirection, maxRange);
+        System.Array.Sort(hits, (x, y) => x.distance.CompareTo(y.distance));
+
+        foreach (RaycastHit hit in hits)
+        {
+            if (hit.collider.CompareTag("Player"))
+            {
+                ApplyDamage(hit.collider.GetComponent<Player.Player>(), hit.point, beamIndex);
+                hitPlayer = true;
+
+                if (!canPenetrate)
+                {
+                    endPos = hit.point;
+                    break;
+                }
+            }
+            else if (hit.collider.CompareTag("Wall") || hit.collider.CompareTag("Obstacle"))
+            {
+                if (!hitPlayer)
+                {
+                    endPos = hit.point;
+                }
+                break;
+            }
+        }
+
+        // 빔 렌더링
+        if (beam != null)
+        {
+            beam.enabled = true;
+            // 최종 두께 설정
+            float finalWidth = beamWidth * (beamIndex == 0 ? 1f : 0.7f);
+            beam.startWidth = finalWidth;
+            beam.endWidth = finalWidth * 0.5f;
+            beam.SetPosition(0, startPos);
+            beam.SetPosition(1, endPos);
+
+            // 충격 이펙트 생성
+            if (hitPlayer || Vector3.Distance(startPos, endPos) < maxRange)
+            {
+                CreateImpactEffect(endPos, beamIndex);
+            }
+        }
+    }
+
+    private Vector3 RotateDirection(Vector3 baseDirection, float angleInDegrees)
+    {
+        // Y축 기준으로 회전 (수평 확산)
+        float radians = angleInDegrees * Mathf.Deg2Rad;
+        float cos = Mathf.Cos(radians);
+        float sin = Mathf.Sin(radians);
+
+        return new Vector3(
+            baseDirection.x * cos - baseDirection.z * sin,
+            baseDirection.y,
+            baseDirection.x * sin + baseDirection.z * cos
+        );
+    }
+
+    private void ApplyDamage(Player.Player player, Vector3 hitPoint, int beamIndex)
+    {
+        if (player == null) return;
+
+        // 임시 보스 스탯 생성
+        EnemyStatSystem tempEnemyStats = new EnemyStatSystem(EnemyType.MiddleBoss);
+
+        // 정확한 데미지 계산
+        float calculatedDamage = DamageCalculator.CalculateDamageToPlayer(
+            tempEnemyStats,
+            elementType,
+            damageType,
+            player.GetPlayerStat(),
+            ElementType.Neutral
+        );
+
+        // 중앙빔이 가장 강하고 바깥쪽 빔이 약함
+        float damageMultiplier = beamIndex == 0 ? 1f : 0.7f - (beamIndex * 0.1f);
+        calculatedDamage *= damageMultiplier;
+
+        player.DecreaseHP(calculatedDamage);
+        Debug.Log($"플레이어가 레일건 빔 {beamIndex}에 맞음! 데미지: {calculatedDamage:F1}");
+    }
+
+    private void CreateImpactEffect(Vector3 position, int beamIndex)
+    {
+        // 빔별로 다른 크기의 충격 이펙트
+        float effectSize = beamIndex == 0 ? 2f : 1.5f - (beamIndex * 0.2f);
+
+        GameObject impact = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        impact.name = $"RailgunImpact_{beamIndex}";
+        impact.transform.position = position;
+        impact.transform.localScale = Vector3.one * effectSize;
+
+        Renderer renderer = impact.GetComponent<Renderer>();
+        Material material = new Material(Shader.Find("Standard"));
+        material.color = Color.cyan;
+        material.EnableKeyword("_EMISSION");
+        material.SetColor("_EmissionColor", Color.cyan * (3f - beamIndex * 0.5f));
+        renderer.material = material;
+
+        DestroyImmediate(impact.GetComponent<Collider>());
+        Destroy(impact, 1f);
+    }
+
+    private void PlayFireSound()
+    {
+        if (audioSource != null && fireSound != null)
+        {
+            audioSource.PlayOneShot(fireSound);
+        }
+    }
+
+    private void CleanupEffects()
+    {
+        // 모든 빔 끄기
+        for (int i = 0; i < allBeams.Length; i++)
+        {
+            if (allBeams[i] != null)
+                allBeams[i].enabled = false;
+        }
+
+        if (chargingParticle != null)
+            chargingParticle.Stop();
+    }
+
+    // 디버그용 시각화
+    private void OnDrawGizmosSelected()
+    {
+        Gizmos.color = Color.cyan;
+
+        // 5갈래 방향 표시
+        for (int i = 0; i < beamAngles.Length; i++)
+        {
+            Vector3 beamDirection = RotateDirection(direction, beamAngles[i]);
+            Gizmos.color = i == 0 ? Color.white : Color.cyan;
+            Gizmos.DrawRay(transform.position, beamDirection * maxRange);
+        }
+    }
+
+    // 공개 속성
+    public bool IsReady => !isFiring;
+
+    // 빔 각도 런타임 설정
+    public void SetBeamAngles(float[] newAngles)
+    {
+        if (newAngles.Length == 5)
+        {
+            beamAngles = newAngles;
+        }
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_RailgunBeam.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_RailgunBeam.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b7e3a58b20d2cf14ba6e8b0fadca149c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_SwordBeam.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_SwordBeam.cs
@@ -1,0 +1,239 @@
+using UnityEngine;
+using System.Collections;
+
+/// <summary>
+/// 최종보스 빛 모드의 검기 공격
+/// </summary>
+public class Enemy_Final_Boss_SwordBeam : MonoBehaviour
+{
+    [Header("검기 설정")]
+    [SerializeField] private float beamLength = 3f;
+    [SerializeField] private float beamWidth = 1.5f;
+    [SerializeField] private float expandSpeed = 8f;
+    [SerializeField] private float sustainTime = 0.3f;
+
+    [Header("이펙트")]
+    [SerializeField] private LineRenderer beamLine;
+    [SerializeField] private Light beamLight;
+    [SerializeField] private AudioClip slashSound;
+
+    private float damage;
+    private Vector3 velocity;
+    private bool hasHitPlayer = false;
+    private bool isExpanding = true;
+    private float currentLength = 0f;
+    private Rigidbody rb;
+    private AudioSource audioSource;
+    private BoxCollider damageCollider;
+
+    public void Initialize(float beamDamage, Vector3 beamVelocity)
+    {
+        damage = beamDamage;
+        velocity = beamVelocity;
+
+        SetupComponents();
+        StartCoroutine(BeamSequence());
+    }
+
+    private void SetupComponents()
+    {
+        // 리지드바디 설정
+        rb = GetComponent<Rigidbody>();
+        if (rb == null)
+            rb = gameObject.AddComponent<Rigidbody>();
+        rb.useGravity = false;
+        rb.velocity = velocity;
+
+        // 오디오 설정
+        audioSource = GetComponent<AudioSource>();
+        if (audioSource == null)
+            audioSource = gameObject.AddComponent<AudioSource>();
+        audioSource.spatialBlend = 1f;
+
+        // 데미지 콜라이더 설정
+        damageCollider = GetComponent<BoxCollider>();
+        if (damageCollider == null)
+            damageCollider = gameObject.AddComponent<BoxCollider>();
+
+        damageCollider.isTrigger = true;
+        damageCollider.size = new Vector3(beamWidth, beamWidth, beamLength);
+        damageCollider.center = Vector3.forward * (beamLength * 0.5f);
+        damageCollider.enabled = false;
+
+        // 라인 렌더러 설정
+        if (beamLine == null)
+            beamLine = gameObject.AddComponent<LineRenderer>();
+
+        beamLine.material = new Material(Shader.Find("Sprites/Default"));
+        beamLine.material.color = Color.white;
+        beamLine.startWidth = beamWidth;
+        beamLine.endWidth = beamWidth * 0.7f;
+        beamLine.positionCount = 2;
+
+        // 검기 조명 설정
+        if (beamLight == null)
+            beamLight = gameObject.AddComponent<Light>();
+
+        beamLight.type = LightType.Spot;
+        beamLight.color = Color.white;
+        beamLight.intensity = 4f;
+        beamLight.range = beamLength * 2f;
+        beamLight.spotAngle = 30f;
+
+        // 이동 방향으로 회전
+        if (velocity != Vector3.zero)
+            transform.rotation = Quaternion.LookRotation(velocity.normalized);
+
+        // 발사 사운드
+        if (slashSound != null)
+        {
+            audioSource.clip = slashSound;
+            audioSource.Play();
+        }
+    }
+
+    private IEnumerator BeamSequence()
+    {
+        // 1단계: 검기 확장
+        yield return StartCoroutine(ExpandBeam());
+
+        // 2단계: 검기 지속
+        yield return StartCoroutine(SustainBeam());
+
+        // 3단계: 검기 축소 및 소멸
+        yield return StartCoroutine(ShrinkBeam());
+
+        Destroy(gameObject);
+    }
+
+    private IEnumerator ExpandBeam()
+    {
+        isExpanding = true;
+        float targetLength = beamLength;
+
+        while (currentLength < targetLength)
+        {
+            currentLength += expandSpeed * Time.deltaTime;
+            currentLength = Mathf.Min(currentLength, targetLength);
+
+            UpdateBeamVisuals();
+            UpdateBeamCollider();
+
+            yield return null;
+        }
+
+        damageCollider.enabled = true;
+        isExpanding = false;
+    }
+
+    private IEnumerator SustainBeam()
+    {
+        yield return new WaitForSeconds(sustainTime);
+        damageCollider.enabled = false;
+    }
+
+    private IEnumerator ShrinkBeam()
+    {
+        float shrinkSpeed = expandSpeed * 2f;
+
+        while (currentLength > 0f)
+        {
+            currentLength -= shrinkSpeed * Time.deltaTime;
+            currentLength = Mathf.Max(currentLength, 0f);
+
+            UpdateBeamVisuals();
+
+            if (beamLight != null)
+            {
+                beamLight.intensity = Mathf.Lerp(4f, 0f, 1f - (currentLength / beamLength));
+            }
+
+            yield return null;
+        }
+    }
+
+    private void UpdateBeamVisuals()
+    {
+        Vector3 startPos = transform.position;
+        Vector3 endPos = startPos + transform.forward * currentLength;
+
+        // 라인 렌더러 업데이트
+        if (beamLine != null)
+        {
+            beamLine.SetPosition(0, startPos);
+            beamLine.SetPosition(1, endPos);
+
+            if (isExpanding)
+            {
+                float progress = currentLength / beamLength;
+                beamLine.material.color = Color.Lerp(Color.yellow, Color.white, progress);
+            }
+        }
+
+        // 조명 범위 업데이트
+        if (beamLight != null)
+        {
+            beamLight.range = currentLength;
+            beamLight.transform.rotation = transform.rotation;
+        }
+    }
+
+    private void UpdateBeamCollider()
+    {
+        if (damageCollider != null)
+        {
+            damageCollider.size = new Vector3(beamWidth, beamWidth, currentLength);
+            damageCollider.center = Vector3.forward * (currentLength * 0.5f);
+        }
+    }
+
+    private void Update()
+    {
+        // 벽이나 장애물과 충돌하면 정지
+        RaycastHit hit;
+        if (Physics.Raycast(transform.position, transform.forward, out hit, 1f))
+        {
+            if (hit.collider.CompareTag("Wall") || hit.collider.CompareTag("Environment"))
+            {
+                rb.velocity = Vector3.zero;
+                transform.position = hit.point - transform.forward * 0.5f;
+            }
+        }
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (hasHitPlayer || !damageCollider.enabled) return;
+
+        if (other.CompareTag("Player"))
+        {
+            hasHitPlayer = true;
+
+            Player.Player player = other.GetComponent<Player.Player>();
+            if (player != null)
+            {
+                player.DecreaseHP(damage);
+                StartCoroutine(HitEffect());
+            }
+        }
+    }
+
+    private IEnumerator HitEffect()
+    {
+        if (beamLine != null)
+        {
+            Color originalColor = beamLine.material.color;
+            beamLine.material.color = Color.cyan;
+            yield return new WaitForSeconds(0.1f);
+            beamLine.material.color = originalColor;
+        }
+
+        if (beamLight != null)
+        {
+            float originalIntensity = beamLight.intensity;
+            beamLight.intensity = 8f;
+            yield return new WaitForSeconds(0.1f);
+            beamLight.intensity = originalIntensity;
+        }
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_SwordBeam.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Final_Boss_Projectiles/Enemy_Final_Boss_SwordBeam.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 67902e394f927a2428cf8420d0c84935
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cbb2ccc91acbd1344bda76a21dc9e910
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_Bullet.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_Bullet.cs
@@ -1,0 +1,110 @@
+using UnityEngine;
+using Enemy;
+
+/// <summary>
+/// 중간 보스가 발사하는 투사체 스크립트
+/// 플레이어와 충돌 시 데미지를 주고 사라짐
+/// </summary>
+[RequireComponent(typeof(Rigidbody))]
+[RequireComponent(typeof(Collider))]
+public class Enemy_Middle_Boss_Bullet : MonoBehaviour
+{
+    [Header("투사체 설정")]
+    [SerializeField] private float damage = 20f;
+    [SerializeField] private DamageType damageType = DamageType.Magical;
+    [SerializeField] private ElementType elementType = ElementType.Dark;
+    [SerializeField] private float lifeTime = 1f;
+
+    [Header("시각적 효과")]
+    [SerializeField] private GameObject hitEffect;
+    [SerializeField] private TrailRenderer trail;
+
+    private bool hasHit = false;
+
+    private void Start()
+    {
+        // 수명 설정
+        Destroy(gameObject, lifeTime);
+
+        // 트리거로 설정
+        GetComponent<Collider>().isTrigger = true;
+    }
+
+    /// <summary>
+    /// 투사체 초기화 (보스에서 호출)
+    /// </summary>
+    public void Initialize(float bulletDamage, DamageType bulletDamageType, ElementType bulletElement = ElementType.Dark)
+    {
+        damage = bulletDamage;
+        damageType = bulletDamageType;
+        elementType = bulletElement;
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (hasHit) return;
+
+        if (other.CompareTag("Player"))
+        {
+            Player.Player player = other.GetComponent<Player.Player>();
+            if (player != null)
+            {
+                ApplyDamageSystem(player);
+            }
+            HitTarget();
+        }
+        else if (other.CompareTag("Wall") || other.CompareTag("Obstacle"))
+        {
+            HitTarget();
+        }
+    }
+
+    private void ApplyDamageSystem(Player.Player player)
+    {
+        // 임시 보스 스탯 생성
+        EnemyStatSystem tempEnemyStats = new EnemyStatSystem(EnemyType.MiddleBoss);
+
+        // 정확한 데미지 계산
+        float calculatedDamage = DamageCalculator.CalculateDamageToPlayer(
+            tempEnemyStats,
+            elementType,
+            damageType,
+            player.GetPlayerStat(),
+            ElementType.Neutral
+        );
+
+        // 계산된 데미지 적용
+        player.DecreaseHP(calculatedDamage);
+
+    }
+
+    private void HitTarget()
+    {
+        if (hasHit) return;
+        hasHit = true;
+
+        // 충돌 이펙트 생성
+        if (hitEffect != null)
+        {
+            GameObject effect = Instantiate(hitEffect, transform.position, Quaternion.identity);
+            Destroy(effect, 2f);
+        }
+
+        // 궤적 효과 정리
+        if (trail != null)
+        {
+            trail.autodestruct = true;
+        }
+
+        // 투사체 오브젝트 파괴
+        Destroy(gameObject);
+    }
+
+    private void OnBecameInvisible()
+    {
+        if (!hasHit)
+        {
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_Bullet.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_Bullet.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6124b13501b36543ac44822d09e58a2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_FloorHazard.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_FloorHazard.cs
@@ -1,0 +1,303 @@
+using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+using Enemy;
+using Player;
+
+/// <summary>
+/// 중간보스가 생성하는 장판 위험 지역
+/// 플레이어가 들어가면 지속 데미지를 받음
+/// </summary>
+[DisallowMultipleComponent]
+public class Enemy_Middle_Boss_FloorHazard : MonoBehaviour
+{
+    [Header("장판 설정")]
+    [SerializeField] private float damageInterval = 0.5f; // 데미지 간격
+    [SerializeField] private float warningDuration = 1f; // 경고 시간
+    [SerializeField] private LayerMask playerLayerMask = -1; // 플레이어 레이어
+
+    [Header("이펙트")]
+    [SerializeField] private GameObject warningEffect; // 경고 이펙트
+    [SerializeField] private GameObject hazardEffect; // 장판 이펙트
+    [SerializeField] private AudioClip warningSound; // 경고 사운드
+    [SerializeField] private AudioClip activateSound; // 활성화 사운드
+
+    // 장판 속성
+    private float damage;
+    private float duration;
+    private float radius;
+    private Enemy_Middle_Boss ownerBoss;
+
+    // 상태 관리
+    private bool isWarning = true; // 경고 단계
+    private bool isActive = false; // 활성화 상태
+    private float startTime;
+    private SphereCollider triggerCollider;
+    private AudioSource audioSource;
+
+    // 플레이어 추적
+    private List<Transform> playersInRange = new List<Transform>();
+    private float lastDamageTime;
+
+    /// <summary>
+    /// 장판 초기화
+    /// </summary>
+    public void Initialize(float hazardDamage, float hazardDuration, float hazardRadius, Enemy_Middle_Boss boss)
+    {
+        damage = hazardDamage;
+        duration = hazardDuration;
+        radius = hazardRadius;
+        ownerBoss = boss;
+        startTime = Time.time;
+
+        SetupComponents();
+        StartWarningPhase();
+    }
+
+    private void SetupComponents()
+    {
+        // 트리거 콜라이더 설정
+        triggerCollider = gameObject.GetComponent<SphereCollider>();
+        if (triggerCollider == null)
+        {
+            triggerCollider = gameObject.AddComponent<SphereCollider>();
+        }
+
+        triggerCollider.isTrigger = true;
+        triggerCollider.radius = radius;
+
+        // 오디오 소스 설정
+        audioSource = gameObject.GetComponent<AudioSource>();
+        if (audioSource == null)
+        {
+            audioSource = gameObject.AddComponent<AudioSource>();
+        }
+        audioSource.spatialBlend = 1f; // 3D 사운드
+        audioSource.maxDistance = 20f;
+        audioSource.volume = 0.7f;
+
+        // 위치 조정 (지면에 고정)
+        Vector3 pos = transform.position;
+        pos.y = 0.1f; // 지면보다 살짝 위에
+        transform.position = pos;
+    }
+
+    private void StartWarningPhase()
+    {
+        isWarning = true;
+        isActive = false;
+
+        // 경고 이펙트 활성화
+        if (warningEffect != null)
+        {
+            warningEffect.SetActive(true);
+
+            // 경고 이펙트 크기 조정
+            warningEffect.transform.localScale = Vector3.one * radius * 2f;
+        }
+
+        // 위험 이펙트 비활성화
+        if (hazardEffect != null)
+        {
+            hazardEffect.SetActive(false);
+        }
+
+        // 경고 사운드 재생
+        if (warningSound != null && audioSource != null)
+        {
+            audioSource.clip = warningSound;
+            audioSource.Play();
+        }
+
+        // 경고 시간 후 활성화
+        StartCoroutine(ActivateAfterWarning());
+    }
+
+    private IEnumerator ActivateAfterWarning()
+    {
+        yield return new WaitForSeconds(warningDuration);
+        ActivateHazard();
+    }
+
+    private void ActivateHazard()
+    {
+        isWarning = false;
+        isActive = true;
+
+        // 경고 이펙트 비활성화
+        if (warningEffect != null)
+        {
+            warningEffect.SetActive(false);
+        }
+
+        // 위험 이펙트 활성화
+        if (hazardEffect != null)
+        {
+            hazardEffect.SetActive(true);
+
+            // 위험 이펙트 크기 조정
+            hazardEffect.transform.localScale = Vector3.one * radius * 2f;
+        }
+
+        // 활성화 사운드 재생
+        if (activateSound != null && audioSource != null)
+        {
+            audioSource.clip = activateSound;
+            audioSource.Play();
+        }
+
+        // 지속시간 후 자동 파괴
+        StartCoroutine(DestroyAfterDuration());
+    }
+
+    private IEnumerator DestroyAfterDuration()
+    {
+        yield return new WaitForSeconds(duration - warningDuration);
+        DestroyHazard();
+    }
+
+    private void Update()
+    {
+        // 활성화 상태에서만 데미지 처리
+        if (isActive && playersInRange.Count > 0)
+        {
+            ProcessDamage();
+        }
+    }
+
+    private void ProcessDamage()
+    {
+        if (Time.time - lastDamageTime < damageInterval)
+            return;
+
+        lastDamageTime = Time.time;
+
+        // 범위 내 모든 플레이어에게 데미지
+        for (int i = playersInRange.Count - 1; i >= 0; i--)
+        {
+            Transform player = playersInRange[i];
+
+            if (player == null)
+            {
+                playersInRange.RemoveAt(i);
+                continue;
+            }
+
+            // 플레이어가 정말 범위 내에 있는지 다시 확인
+            float distance = Vector3.Distance(transform.position, player.position);
+            if (distance <= radius)
+            {
+                DealDamageToPlayer(player);
+            }
+            else
+            {
+                playersInRange.RemoveAt(i);
+            }
+        }
+    }
+
+    private void DealDamageToPlayer(Transform player)
+    {
+        // 플레이어 컴포넌트 찾기
+        Player.Player playerComponent = player.GetComponent<Player.Player>();
+        if (playerComponent == null)
+        {
+            playerComponent = player.GetComponentInChildren<Player.Player>();
+        }
+
+        if (playerComponent != null)
+        {
+            // Player 클래스의 DecreaseHP 메서드 사용
+            playerComponent.DecreaseHP(damage);
+        }
+    }
+
+    #region 트리거 이벤트
+
+    private void OnTriggerEnter(Collider other)
+    {
+        // 경고 단계에서는 데미지 없음
+        if (isWarning) return;
+
+        // 플레이어 레이어 체크
+        if (IsPlayer(other.gameObject))
+        {
+            Transform playerTransform = other.transform;
+            if (!playersInRange.Contains(playerTransform))
+            {
+                playersInRange.Add(playerTransform);
+            }
+        }
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (IsPlayer(other.gameObject))
+        {
+            Transform playerTransform = other.transform;
+            playersInRange.Remove(playerTransform);
+        }
+    }
+
+    private bool IsPlayer(GameObject obj)
+    {
+        // 레이어 마스크로 플레이어 판별
+        return ((1 << obj.layer) & playerLayerMask) != 0 ||
+               obj.CompareTag("Player") ||
+               obj.GetComponent<Player.Player>() != null;
+    }
+
+    #endregion
+
+    private void DestroyHazard()
+    {
+        // 보스에게 장판 파괴 알림
+        if (ownerBoss != null)
+        {
+            ownerBoss.OnFloorHazardDestroyed();
+        }
+
+        // 오브젝트 파괴
+        Destroy(gameObject);
+    }
+
+    private void OnDestroy()
+    {
+        // 혹시 모를 안전장치
+        if (ownerBoss != null)
+        {
+            ownerBoss.OnFloorHazardDestroyed();
+        }
+    }
+
+    #region 디버그
+
+    private void OnDrawGizmos()
+    {
+        // 장판 범위 시각화
+        Gizmos.color = isWarning ? Color.yellow : (isActive ? Color.red : Color.gray);
+        Gizmos.DrawWireSphere(transform.position, radius);
+
+        // 중심점 표시
+        Gizmos.color = Color.white;
+        Gizmos.DrawSphere(transform.position, 0.1f);
+    }
+
+    private void OnDrawGizmosSelected()
+    {
+        // 선택했을 때 더 자세한 정보 표시
+        if (isActive && playersInRange.Count > 0)
+        {
+            Gizmos.color = Color.cyan;
+            foreach (Transform player in playersInRange)
+            {
+                if (player != null)
+                {
+                    Gizmos.DrawLine(transform.position, player.position);
+                }
+            }
+        }
+    }
+
+    #endregion
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_FloorHazard.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_FloorHazard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fd743222a87d1724fa5fc061a5376ff1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_Grab.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_Grab.cs
@@ -1,0 +1,113 @@
+using UnityEngine;
+using Enemy;
+
+/// <summary>
+/// 중간보스가 발사하는 그랩 투사체
+/// 플레이어에게 맞으면 보스 쪽으로 끌어당기는 효과 발생
+/// </summary>
+[RequireComponent(typeof(Rigidbody))]
+[RequireComponent(typeof(Collider))]
+public class Enemy_Middle_Boss_Grab : MonoBehaviour
+{
+    [Header("그랩 투사체 설정")]
+    [SerializeField] private float pullForce = 8f;
+    [SerializeField] private float pullDuration = 2f;
+    [SerializeField] private float damage = 40f;
+    [SerializeField] private float lifeTime = 5f;
+
+    [Header("시각적 효과")]
+    [SerializeField] private GameObject hitEffect;
+    [SerializeField] private TrailRenderer trail;
+    [SerializeField] private GameObject grabEffect;
+
+    private bool hasHit = false;
+    private Enemy_Middle_Boss sourceBoss;
+
+    private void Start()
+    {
+        Destroy(gameObject, lifeTime);
+
+        // 트리거로 설정
+        GetComponent<Collider>().isTrigger = true;
+    }
+
+    public void Initialize(Enemy_Middle_Boss boss, float grabPullForce, float grabDuration, float grabDamage)
+    {
+        sourceBoss = boss;
+        pullForce = grabPullForce;
+        pullDuration = grabDuration;
+        damage = grabDamage;
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (hasHit) return;
+
+        if (other.CompareTag("Player"))
+        {
+            Player.Player player = other.GetComponent<Player.Player>();
+            if (player != null && sourceBoss != null)
+            {
+                ApplyGrabEffect(other.transform, player);
+            }
+            HitTarget();
+        }
+        else if (other.CompareTag("Wall") || other.CompareTag("Obstacle"))
+        {
+            HitTarget();
+        }
+    }
+
+    private void ApplyGrabEffect(Transform playerTransform, Player.Player player)
+    {
+        if (sourceBoss != null)
+        {
+            float calculatedDamage = DamageCalculator.CalculateDamageToPlayer(
+                sourceBoss.GetEnemyStats(),
+                sourceBoss.GetElementType(),
+                DamageType.Physical, // 그랩은 물리 데미지로 가정
+                player.GetPlayerStat(),
+                ElementType.Neutral
+            );
+
+            player.DecreaseHP(calculatedDamage);
+        }
+        
+        // 그랩 이펙트 생성
+        if (grabEffect != null)
+        {
+            GameObject effect = Instantiate(grabEffect, playerTransform.position, Quaternion.identity);
+            Destroy(effect, pullDuration);
+        }
+
+        // 보스에게 그랩 성공 알림
+        sourceBoss.OnGrabProjectileHit(playerTransform, pullForce, pullDuration);
+    }
+
+    private void HitTarget()
+    {
+        if (hasHit) return;
+        hasHit = true;
+
+        if (hitEffect != null)
+        {
+            GameObject effect = Instantiate(hitEffect, transform.position, Quaternion.identity);
+            Destroy(effect, 2f);
+        }
+
+        if (trail != null)
+        {
+            trail.autodestruct = true;
+        }
+
+        Destroy(gameObject);
+    }
+
+    private void OnBecameInvisible()
+    {
+        if (!hasHit)
+        {
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_Grab.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_Grab.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3bea17bf4e7495e478113b547792ced1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_Railgun.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_Railgun.cs
@@ -1,0 +1,353 @@
+// Enemy_Middle_Boss_Railgun.cs (명중률 개선 버전)
+using UnityEngine;
+using Enemy;
+using System.Collections;
+
+/// <summary>
+/// 보스 차징 레일건 공격 - 명중률 개선
+/// </summary>
+public class Enemy_Middle_Boss_Railgun : MonoBehaviour
+{
+    [Header("레일건 설정")]
+    [SerializeField] private float damage = 120f;
+    [SerializeField] private float maxRange = 50f;
+    [SerializeField] private float beamWidth = 3f;
+    [SerializeField] private float chargingTime = 1f;
+    [SerializeField] private float flashDuration = 0.3f;
+    [SerializeField] private bool canPenetrate = true;
+    [SerializeField] private bool enablePrediction = true;   // 예측 조준
+    [SerializeField] private float predictionTime = 0.5f;    // 예측 시간
+
+    [Header("데미지 속성")]
+    [SerializeField] private DamageType damageType = DamageType.Magical;
+    [SerializeField] private ElementType elementType = ElementType.Dark;
+
+    [Header("컴포넌트")]
+    [SerializeField] private LineRenderer railgunBeam;        // 중앙 빔
+    [SerializeField] private LineRenderer leftBeam;           // 좌측 빔
+    [SerializeField] private LineRenderer rightBeam;          // 우측 빔
+    [SerializeField] private ParticleSystem chargingParticle;
+
+    [Header("사운드")]
+    [SerializeField] private AudioClip fireSound;
+
+    private Enemy_Base sourceBoss;
+    private Transform firePoint;
+    private AudioSource audioSource;
+    private bool isFiring = false;
+
+    #region 초기화
+
+    private void Start()
+    {
+        // 컴포넌트 자동 찾기
+        if (railgunBeam == null)
+            railgunBeam = GetComponent<LineRenderer>();
+        if (chargingParticle == null)
+            chargingParticle = GetComponent<ParticleSystem>();
+        if (audioSource == null)
+            audioSource = GetComponent<AudioSource>();
+
+        SetupRailgunBeams();
+        SetupChargingParticle();
+    }
+
+    public void Initialize(Enemy_Base boss, Transform shootPoint)
+    {
+        sourceBoss = boss;
+        firePoint = shootPoint;
+    }
+
+    private void SetupRailgunBeams()
+    {
+        // 중앙 빔 설정
+        SetupSingleBeam(railgunBeam);
+
+        // 좌측 빔 설정
+        SetupSingleBeam(leftBeam);
+
+        // 우측 빔 설정
+        SetupSingleBeam(rightBeam);
+    }
+
+    private void SetupSingleBeam(LineRenderer beam)
+    {
+        if (beam != null)
+        {
+            // 빔 기본 설정
+            beam.startWidth = beamWidth * 2f;
+            beam.endWidth = beamWidth * 1.2f;
+            beam.enabled = false;
+            beam.useWorldSpace = true;
+            beam.positionCount = 2;
+
+            // 빔 스타일 설정
+            beam.textureMode = LineTextureMode.Stretch;
+            beam.alignment = LineAlignment.View;
+            beam.numCapVertices = 8;
+            beam.numCornerVertices = 8;
+
+            // 그라디언트 색상
+            Gradient gradient = new Gradient();
+            gradient.SetKeys(
+                new GradientColorKey[] {
+                    new GradientColorKey(Color.white, 0.0f),
+                    new GradientColorKey(Color.cyan, 1.0f)
+                },
+                new GradientAlphaKey[] {
+                    new GradientAlphaKey(1.0f, 0.0f),
+                    new GradientAlphaKey(0.3f, 1.0f)
+                }
+            );
+            beam.colorGradient = gradient;
+        }
+    }
+
+    private void SetupChargingParticle()
+    {
+        if (chargingParticle != null)
+        {
+            chargingParticle.Stop();
+
+            var main = chargingParticle.main;
+            main.playOnAwake = false;
+            main.startColor = Color.cyan;
+            main.startSize = 1f;
+            main.startLifetime = 1f;
+        }
+    }
+
+    #endregion
+
+    #region 차징 레일건
+
+    public void FireInstantRailgun(Vector3 targetPosition)
+    {
+        if (isFiring) return;
+
+        StartCoroutine(ChargingRailgunSequence(targetPosition));
+    }
+
+    private IEnumerator ChargingRailgunSequence(Vector3 targetPosition)
+    {
+        isFiring = true;
+
+        // 1. 차징 페이즈
+        yield return StartCoroutine(ChargingPhase());
+
+        // 2. 발사 페이즈
+        FireRailgunBeam(targetPosition);
+        PlayFireSound();
+
+        // 3. 섬광 시간
+        yield return new WaitForSeconds(flashDuration);
+
+        // 4. 정리
+        CleanupEffects();
+        isFiring = false;
+    }
+
+    private IEnumerator ChargingPhase()
+    {
+        // 차징 파티클 시작
+        if (chargingParticle != null && firePoint != null)
+        {
+            chargingParticle.transform.position = firePoint.position;
+            chargingParticle.Play();
+        }
+
+        // 차징 시간 대기
+        yield return new WaitForSeconds(chargingTime);
+
+        // 차징 완료 - 파티클 정지
+        if (chargingParticle != null)
+        {
+            chargingParticle.Stop();
+        }
+    }
+
+    private void FireRailgunBeam(Vector3 targetDirection)
+    {
+        Vector3 startPos = firePoint.position;
+        Vector3 finalTarget = targetDirection;
+
+        // 예측 조준 시스템
+        if (enablePrediction && sourceBoss != null)
+        {
+            finalTarget = PredictPlayerPosition(targetDirection);
+        }
+
+        Vector3 baseDirection = (finalTarget - startPos).normalized;
+
+        // Y축 완전 고정 (수평 발사)
+        baseDirection.y = 0;
+        baseDirection = baseDirection.normalized;
+
+        // 3갈래 방향 계산
+        Vector3 centerDirection = baseDirection;
+        Vector3 leftDirection = RotateDirection(baseDirection, 15f);   // 좌측 15도
+        Vector3 rightDirection = RotateDirection(baseDirection, -15f); // 우측 15도
+
+        // 각 방향별로 레이캐스트 및 빔 표시
+        Vector3 centerEnd = FireSingleBeam(startPos, centerDirection, railgunBeam);
+        Vector3 leftEnd = FireSingleBeam(startPos, leftDirection, leftBeam);
+        Vector3 rightEnd = FireSingleBeam(startPos, rightDirection, rightBeam);
+    }
+
+    private Vector3 FireSingleBeam(Vector3 startPos, Vector3 direction, LineRenderer beam)
+    {
+        Vector3 endPos = startPos + direction * maxRange;
+        bool hitPlayer = false;
+
+        // 레이캐스트로 충돌 검사
+        RaycastHit[] hits = Physics.RaycastAll(startPos, direction, maxRange);
+        System.Array.Sort(hits, (x, y) => x.distance.CompareTo(y.distance));
+
+        foreach (RaycastHit hit in hits)
+        {
+            if (hit.collider.CompareTag("Player"))
+            {
+                ApplyInstantDamage(hit.collider.GetComponent<Player.Player>(), hit.point);
+                hitPlayer = true;
+
+                if (!canPenetrate)
+                {
+                    endPos = hit.point;
+                    break;
+                }
+            }
+            else if (hit.collider.CompareTag("Wall") || hit.collider.CompareTag("Obstacle"))
+            {
+                if (!hitPlayer)
+                {
+                    endPos = hit.point;
+                }
+                break;
+            }
+        }
+
+        // 빔 표시
+        if (beam != null)
+        {
+            beam.enabled = true;
+            beam.positionCount = 2;
+            beam.SetPosition(0, startPos);
+            beam.SetPosition(1, endPos);
+        }
+
+        return endPos;
+    }
+
+    private Vector3 PredictPlayerPosition(Vector3 currentPlayerPos)
+    {
+        GameObject playerObj = GameObject.FindWithTag("Player");
+        if (playerObj == null) return currentPlayerPos;
+
+        // 예측된 위치도 Y축 고정
+        Vector3 predictedPos = currentPlayerPos;
+
+        // 플레이어의 이동 속도 계산
+        Rigidbody playerRb = playerObj.GetComponent<Rigidbody>();
+        if (playerRb != null)
+        {
+            Vector3 playerVelocity = playerRb.velocity;
+            playerVelocity.y = 0; // Y축 속도 무시
+            predictedPos = currentPlayerPos + playerVelocity * predictionTime;
+        }
+        else
+        {
+            // Rigidbody가 없으면 기본 예측
+            Vector3 toPlayer = (currentPlayerPos - firePoint.position).normalized;
+            toPlayer.y = 0; // Y축 방향 무시
+            float distanceToPlayer = Vector3.Distance(firePoint.position, currentPlayerPos);
+            float timeToReach = distanceToPlayer / 30f;
+
+            predictedPos = currentPlayerPos + toPlayer * timeToReach * 2f;
+        }
+
+        // 예측 위치의 Y축도 보스와 같은 높이로 고정
+        predictedPos.y = firePoint.position.y;
+
+        return predictedPos;
+    }
+
+    private Vector3 RotateDirection(Vector3 direction, float angleInDegrees)
+    {
+        float radians = angleInDegrees * Mathf.Deg2Rad;
+        float cos = Mathf.Cos(radians);
+        float sin = Mathf.Sin(radians);
+
+        return new Vector3(
+            direction.x * cos - direction.z * sin,
+            direction.y,
+            direction.x * sin + direction.z * cos
+        );
+    }
+
+    private void ApplyInstantDamage(Player.Player player, Vector3 hitPoint)
+    {
+        if (player == null) return;
+
+        if (sourceBoss != null)
+        {
+            float calculatedDamage = DamageCalculator.CalculateDamageToPlayer(
+                sourceBoss.GetEnemyStats(),
+                elementType,
+                damageType,
+                player.GetPlayerStat(),
+                ElementType.Neutral
+            );
+
+            // 순간딜 보너스
+            calculatedDamage *= 2.0f;
+
+            player.DecreaseHP(calculatedDamage);
+        }
+        else
+        {
+            player.DecreaseHP(damage);
+        }
+    }
+
+    #endregion
+
+    #region 시각적 효과
+
+    private void PlayFireSound()
+    {
+        if (audioSource != null && fireSound != null)
+        {
+            audioSource.PlayOneShot(fireSound);
+        }
+    }
+
+    private void CleanupEffects()
+    {
+        // 3개 빔 모두 끄기
+        if (railgunBeam != null)
+            railgunBeam.enabled = false;
+        if (leftBeam != null)
+            leftBeam.enabled = false;
+        if (rightBeam != null)
+            rightBeam.enabled = false;
+
+        if (chargingParticle != null)
+            chargingParticle.Stop();
+    }
+
+    #endregion
+
+    #region 퍼블릭 접근자
+
+    public bool IsReady => !isFiring;
+
+    public void SetChargingRailgunProperties(float newDamage, float newRange, float newChargingTime, DamageType newDamageType)
+    {
+        damage = newDamage;
+        maxRange = newRange;
+        chargingTime = newChargingTime;
+        damageType = newDamageType;
+    }
+
+    #endregion
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_Railgun.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Projectiles/Middle_Boss_Projectiles/Enemy_Middle_Boss_Railgun.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 84f08bbe1eb3986438a5b7689111793c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cfbde60fe62f5af40a7dc8d75eabc467
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Ranged.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Ranged.cs
@@ -1,0 +1,181 @@
+using UnityEngine;
+using Enemy;
+
+/// <summary>
+/// 기존 원거리 코드를 Enemy_Base에 통합 (AD형)
+/// </summary>
+[DisallowMultipleComponent]
+public class Enemy_Ranged : Enemy_Base
+{
+    [Header("원거리 공격 설정")]
+    public GameObject bulletPrefab;      // 총알 프리팹
+    public Transform firePoint;          // 총알 발사 위치
+    public float attackRange = 8f;       // 공격 사거리
+    public float attackCooldown = 2f;    // 공격 쿨다운
+    public float attackDuration = 0.5f;  // 공격 지속 시간 (멈춰있는 시간)
+
+    private float lastAttackTime;
+    private bool isAttacking = false;    // 공격 중인지 여부
+
+    // Move 스크립트에서 참조할 수 있는 프로퍼티 (기존과 동일)
+    public bool IsAttacking => isAttacking;
+
+    #region Enemy_Base 오버라이드
+
+    protected override void InitializeEnemy()
+    {
+        // 새로운 시스템 설정
+        enemyType = EnemyType.RangedAD;
+        primaryDamageType = DamageType.Physical; // AD 딜러이므로 물리 데미지
+
+        // 기존 초기화 로직
+        if (firePoint == null)
+        {
+            Transform childFirePoint = transform.Find("FirePoint");
+            if (childFirePoint != null)
+            {
+                firePoint = childFirePoint;
+            }
+        }
+
+        // 새로운 스탯 시스템의 값으로 기존 설정 업데이트
+        attackRange = enemyStats.Get(EnemyStatType.AttackRange);
+        attackCooldown = 1f / enemyStats.Get(EnemyStatType.AttackSpeed);
+
+        base.InitializeEnemy();
+    }
+
+    protected override void UpdateBehavior()
+    {
+        if (playerTransform == null) return;
+
+        float distanceToPlayer = Vector3.Distance(transform.position, playerTransform.position);
+        HandleCombat(distanceToPlayer);
+    }
+
+    protected override void PerformAttack()
+    {
+        // 기존 Attack 로직 그대로 사용 + 새로운 시스템 추가
+        if (bulletPrefab != null && firePoint != null && playerTransform != null)
+        {
+            // 공격 시작
+            isAttacking = true;
+
+            // 총알 복제 생성 (기존 로직)
+            GameObject bullet = Instantiate(bulletPrefab, firePoint.position, firePoint.rotation);
+
+            // 플레이어 방향으로 총알 회전 (기존 로직)
+            Vector3 targetPos = playerTransform.position;
+            targetPos.y = firePoint.position.y;
+            bullet.transform.LookAt(targetPos);
+
+            // 기존 총알 시스템에 새로운 스탯 적용
+            var bulletComponent = bullet.GetComponent<Enemy_Ranged_Bullet>();
+            
+
+            lastAttackTime = Time.time;
+
+            // 일정 시간 후 공격 상태 해제 (기존 로직)
+            Invoke(nameof(EndAttack), attackDuration);
+
+        }
+    }
+
+    protected override void UpdateMovement()
+    {
+        // 이동은 Enemy_Ranged_Move에서 처리하므로 비워둠
+        // Enemy_Ranged_Move가 IsAttacking 프로퍼티를 참조해서 움직임 제어
+    }
+
+    #endregion
+
+    #region 기존 로직 유지
+
+    private void HandleCombat(float distanceToPlayer)
+    {
+        LookAtPlayer();
+
+        if (distanceToPlayer <= attackRange && Time.time > lastAttackTime + attackCooldown)
+        {
+            PerformAttack(); // Enemy_Base의 추상 메서드 호출
+        }
+    }
+
+    private void LookAtPlayer()
+    {
+        if (playerTransform == null) return;
+
+        Vector3 direction = (playerTransform.position - transform.position).normalized;
+        direction.y = 0;
+
+        if (direction != Vector3.zero)
+        {
+            transform.rotation = Quaternion.LookRotation(direction);
+        }
+    }
+
+    private void EndAttack()
+    {
+        isAttacking = false;
+    }
+
+    #endregion
+
+    #region 기존 Gizmo (유지)
+
+    private void OnDrawGizmosSelected()
+    {
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireSphere(transform.position, attackRange);
+
+        // 새로운 시스템: 감지 범위도 표시
+        if (enemyStats != null)
+        {
+            Gizmos.color = Color.yellow;
+            Gizmos.DrawWireSphere(transform.position, enemyStats.Get(EnemyStatType.DetectionRange));
+        }
+    }
+
+    #endregion
+
+    #region 추가 기능 (선택사항)
+
+    /// <summary>
+    /// 인스펙터에서 실시간으로 스탯 확인 가능
+    /// </summary>
+    [System.Serializable]
+    public class RuntimeStats
+    {
+        [SerializeField] private float currentHP;
+        [SerializeField] private float physicalDamage;
+        [SerializeField] private float attackSpeed;
+        [SerializeField] private float moveSpeed;
+
+        public void UpdateStats(Enemy_Ranged enemy)
+        {
+            if (enemy.enemyStats != null)
+            {
+                currentHP = enemy.currentHp;
+                physicalDamage = enemy.enemyStats.Get(EnemyStatType.PhysicalDamage);
+                attackSpeed = enemy.enemyStats.Get(EnemyStatType.AttackSpeed);
+                moveSpeed = enemy.enemyStats.Get(EnemyStatType.MoveSpeed);
+            }
+        }
+    }
+
+    [Header("실시간 스탯 확인 (읽기전용)")]
+    [SerializeField] private RuntimeStats runtimeStats = new RuntimeStats();
+
+    protected override void Update()
+    {
+        base.Update();
+
+        // 디버그용: 실시간 스탯 업데이트
+        if (Application.isEditor)
+        {
+            runtimeStats.UpdateStats(this);
+        }
+    }
+
+    #endregion
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Ranged.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Ranged.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 264463a6ed758824a81431e64100c27b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Ranged_Move.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Ranged_Move.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class Enemy_Ranged_Move : MonoBehaviour
+{
+    [SerializeField] private float speed = 2f;
+
+    private Transform target;
+    private Rigidbody rigid;
+    private Enemy_Ranged enemyRanged; // Enemy_Ranged 참조 추가
+
+    private void Start()
+    {
+        target = GameObject.Find("Player").transform;
+        rigid = GetComponent<Rigidbody>();
+        enemyRanged = GetComponent<Enemy_Ranged>(); // 참조 가져오기
+    }
+
+    private void FixedUpdate()
+    {
+        // 공격 중이 아닐 때만 이동
+        if (enemyRanged == null || !enemyRanged.IsAttacking)
+            Move();
+        else
+        {
+            // 공격 중일 때는 멈춤
+            if (rigid != null)
+            {
+                rigid.velocity = Vector3.zero;
+            }
+        }
+    }
+
+    private void Move()
+    {
+        if (target == null) return;
+
+        Vector3 dirVector = target.position - transform.position;
+        dirVector.y = 0;
+
+        Vector3 moveVector = dirVector.normalized * speed * Time.fixedDeltaTime;
+        rigid.MovePosition(rigid.position + moveVector);
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Ranged_Move.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Ranged_Move.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9aa01c0472138434e94d6ffe6d34780d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Wizard.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Wizard.cs
@@ -1,0 +1,145 @@
+using UnityEngine;
+using Enemy;
+
+/// <summary>
+/// 마법사 적 클래스 - Enemy_Base에 통합 (AP형)
+/// </summary>
+[DisallowMultipleComponent]
+public class Enemy_Wizard : Enemy_Base
+{
+    [Header("마법사 공격 설정")]
+    public GameObject magicOrbPrefab;     // 마법 구체 프리팹
+    public Transform castPoint;           // 마법 시전 위치
+    public float attackRange = 10f;       // 공격 사거리
+    public float attackCooldown = 2.5f;   // 공격 쿨다운
+    public float castDuration = 0.5f;     // 마법 시전 지속 시간 (멈춰있는 시간)
+    public float orbSpeed = 6f;           // 마법 구체 속도
+
+    private float lastAttackTime;
+    private bool isCasting = false;       // 마법 시전 중인지 여부
+
+    // Move 스크립트에서 참조할 수 있는 프로퍼티
+    public bool IsCasting => isCasting;
+
+    #region Enemy_Base 오버라이드
+
+    protected override void InitializeEnemy()
+    {
+        // 스탯 시스템 설정
+        enemyType = EnemyType.RangedAP;
+        primaryDamageType = DamageType.Magical; // AP 드라이버로 마법 데미지
+
+        // 기본 초기화 로직
+        if (castPoint == null)
+        {
+            Transform childCastPoint = transform.Find("CastPoint");
+            if (childCastPoint != null)
+            {
+                castPoint = childCastPoint;
+            }
+        }
+
+        // 스탯 시스템의 값으로 기본 설정 업데이트
+        attackRange = enemyStats.Get(EnemyStatType.AttackRange);
+        attackCooldown = 1f / enemyStats.Get(EnemyStatType.AttackSpeed);
+
+        base.InitializeEnemy();
+    }
+
+    protected override void UpdateBehavior()
+    {
+        if (playerTransform == null) return;
+
+        float distanceToPlayer = Vector3.Distance(transform.position, playerTransform.position);
+        HandleCombat(distanceToPlayer);
+    }
+
+    protected override void PerformAttack()
+    {
+        // 기본 마법 구체 공격
+        if (magicOrbPrefab != null && castPoint != null && playerTransform != null)
+        {
+            // 시전 시작
+            isCasting = true;
+
+            // 마법 구체 복제 생성
+            GameObject orb = Instantiate(magicOrbPrefab, castPoint.position, castPoint.rotation);
+
+            // 플레이어 방향으로 마법 구체 회전
+            Vector3 targetPos = playerTransform.position;
+            targetPos.y = castPoint.position.y;
+            orb.transform.LookAt(targetPos);
+
+            // 마법 구체에 스탯 적용
+            var orbComponent = orb.GetComponent<Enemy_Wizard_MagicOrb>();
+            
+
+            lastAttackTime = Time.time;
+
+            // 일정 시간 후 시전 상태 해제
+            Invoke(nameof(EndCasting), castDuration);
+
+            Debug.Log($"{enemyName} 마법 구체 공격! 마법 데미지: {GetMainDamage()}");
+        }
+    }
+
+    protected override void UpdateMovement()
+    {
+        // 이동은 Enemy_Wizard_Move에서 처리하므로 비워둠
+    }
+
+    #endregion
+
+    #region 마법사 전용 로직
+
+    private void HandleCombat(float distanceToPlayer)
+    {
+        LookAtPlayer();
+
+        // 기본 마법 구체 공격만
+        if (distanceToPlayer <= attackRange && Time.time > lastAttackTime + attackCooldown && !isCasting)
+        {
+            PerformAttack();
+        }
+    }
+
+    private void LookAtPlayer()
+    {
+        if (playerTransform == null) return;
+
+        Vector3 direction = (playerTransform.position - transform.position).normalized;
+        direction.y = 0;
+
+        if (direction != Vector3.zero)
+        {
+            transform.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(direction), Time.deltaTime * 2f);
+        }
+    }
+
+    private void EndCasting()
+    {
+        isCasting = false;
+        Debug.Log($"{enemyName} 마법 시전 완료, 이동 재개");
+    }
+
+
+    #endregion
+
+    #region 기즈모 (유지)
+
+    private void OnDrawGizmosSelected()
+    {
+        // 기본 공격 범위
+        Gizmos.color = Color.blue;
+        Gizmos.DrawWireSphere(transform.position, attackRange);
+
+        // 스탯 시스템: 감지 범위 표시
+        if (enemyStats != null)
+        {
+            Gizmos.color = Color.yellow;
+            Gizmos.DrawWireSphere(transform.position, enemyStats.Get(EnemyStatType.DetectionRange));
+        }
+    }
+
+    #endregion
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Wizard.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Wizard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2470df3c540752447b581f9f6d3bf40f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Wizard_Move.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Wizard_Move.cs
@@ -1,0 +1,228 @@
+using UnityEngine;
+
+/// <summary>
+/// 마법사 적의 이동 제어 스크립트 (완성된 버전)
+/// </summary>
+[DisallowMultipleComponent]
+public class Enemy_Wizard_Move : MonoBehaviour
+{
+    [Header("이동 설정")]
+    [SerializeField] private float speed = 1.8f;
+    [SerializeField] private float optimalDistance = 8f;    // 공격 사거리
+
+    [Header("마법사 행동 패턴")]
+    [SerializeField] private float repositionTime = 3f;    // 위치 재조정 시간 간격
+
+    private Transform target;
+    private Rigidbody rigid;
+    private Enemy_Wizard enemyWizard;
+    private Vector3 lastRepositionTime;
+    private Vector3 targetPosition;
+    private bool isRepositioning = false;
+
+    private void Start()
+    {
+        target = GameObject.FindGameObjectWithTag("Player")?.transform;
+        if (target == null)
+        {
+            target = GameObject.Find("Player")?.transform;
+        }
+
+        rigid = GetComponent<Rigidbody>();
+        enemyWizard = GetComponent<Enemy_Wizard>();
+
+        targetPosition = transform.position;
+        lastRepositionTime = Vector3.zero;
+    }
+
+    private void FixedUpdate()
+    {
+        // 기본 조건 체크
+        if (enemyWizard == null || target == null || enemyWizard.IsDead())
+        {
+            StopMovement();
+            return;
+        }
+
+        // 마법 시전 중에는 이동 중지
+        if (enemyWizard.IsCasting)
+        {
+            StopMovement();
+            return;
+        }
+
+        // 일반 이동 로직
+        HandleMovement();
+    }
+
+    private void HandleMovement()
+    {
+        if (target == null) return;
+
+        float distanceToPlayer = Vector3.Distance(transform.position, target.position);
+
+        // 최적 거리보다 멀면 접근
+        if (distanceToPlayer > optimalDistance)
+        {
+            MoveTowardsPlayer();
+        }
+        else if (ShouldReposition())
+        {
+            // 일정 시간마다 위치 재조정 (측면 이동)
+            PerformRepositioning();
+        }
+        else
+        {
+            // 최적 거리에서는 천천히 이동하거나 정지
+            SlowMovement();
+        }
+    }
+
+    private void MoveTowardsPlayer()
+    {
+        Vector3 dirVector = (target.position - transform.position).normalized;
+        dirVector.y = 0;
+
+        Vector3 moveVector = dirVector * speed * Time.fixedDeltaTime;
+        Vector3 newPosition = rigid.position + moveVector;
+        newPosition.y = rigid.position.y; // Y축 위치 고정
+        rigid.MovePosition(newPosition);
+
+        isRepositioning = false;
+    }
+
+    private bool ShouldReposition()
+    {
+        return Time.time > lastRepositionTime.x + repositionTime && !isRepositioning;
+    }
+
+    private void PerformRepositioning()
+    {
+        // 측면으로 이동할 위치 계산
+        Vector3 playerToWizard = (transform.position - target.position).normalized;
+        Vector3 rightDirection = Vector3.Cross(playerToWizard, Vector3.up);
+
+        // 랜덤하게 좌우 선택
+        float sideDirection = Random.value > 0.5f ? 1f : -1f;
+        Vector3 sideOffset = rightDirection * sideDirection * Random.Range(3f, 6f);
+
+        // 최적 거리 유지하면서 측면 이동
+        Vector3 optimalPositionFromPlayer = target.position + playerToWizard * optimalDistance;
+        targetPosition = optimalPositionFromPlayer + sideOffset;
+        targetPosition.y = transform.position.y; // Y축 위치 고정
+
+        isRepositioning = true;
+        lastRepositionTime.x = Time.time;
+
+        // 재조정 완료까지의 시간 설정
+        Invoke(nameof(FinishRepositioning), 2f);
+    }
+
+    private void FinishRepositioning()
+    {
+        isRepositioning = false;
+    }
+
+    private void SlowMovement()
+    {
+        if (isRepositioning)
+        {
+            // 목표 위치로 이동
+            Vector3 dirToTarget = (targetPosition - transform.position).normalized;
+            dirToTarget.y = 0;
+
+            Vector3 moveVector = dirToTarget * speed * 0.5f * Time.fixedDeltaTime;
+            Vector3 newPosition = rigid.position + moveVector;
+            newPosition.y = rigid.position.y; // Y축 위치 고정
+
+            // 목표 위치에 거의 도달했으면 정지
+            if (Vector3.Distance(transform.position, targetPosition) < 1f)
+            {
+                isRepositioning = false;
+                return;
+            }
+
+            rigid.MovePosition(newPosition);
+        }
+        else
+        {
+            // 최적 거리에서는 거의 정지하거나 매우 천천히 이동
+            Vector3 dirVector = (target.position - transform.position).normalized;
+            dirVector.y = 0;
+
+            Vector3 moveVector = dirVector * speed * 0.2f * Time.fixedDeltaTime;
+            Vector3 newPosition = rigid.position + moveVector;
+            newPosition.y = rigid.position.y; // Y축 위치 고정
+            rigid.MovePosition(newPosition);
+        }
+    }
+
+    private void StopMovement()
+    {
+        if (rigid != null)
+        {
+            // X, Z축 속도만 0으로 설정, Y축은 중력 유지
+            rigid.velocity = new Vector3(0, rigid.velocity.y, 0);
+        }
+    }
+
+    #region 공개 메서드
+
+    /// <summary>
+    /// 외부에서 이동 속도 조정 (스탯 시스템 연동용)
+    /// </summary>
+    public void SetMoveSpeed(float newSpeed)
+    {
+        speed = newSpeed;
+    }
+
+    /// <summary>
+    /// 최적 거리 설정 (난이도 조정용)
+    /// </summary>
+    public void SetOptimalDistance(float distance)
+    {
+        optimalDistance = distance;
+    }
+
+    /// <summary>
+    /// 강제 위치 재조정 (스킬 사용 후 등)
+    /// </summary>
+    public void ForceReposition()
+    {
+        lastRepositionTime.x = 0; // 즉시 재조정 가능하게
+        isRepositioning = false;
+    }
+
+    #endregion
+
+    #region 디버깅 기능들
+
+    private void OnDrawGizmosSelected()
+    {
+        if (target == null) return;
+
+        Vector3 wizardPos = transform.position;
+
+        // 마법사 위치 표시
+        Gizmos.color = Color.green;
+        Gizmos.DrawWireSphere(wizardPos, 0.5f);
+
+        // 최적 거리 (공격 사거리) 표시
+        Gizmos.color = Color.blue;
+        Gizmos.DrawWireSphere(target.position, optimalDistance);
+
+        // 목표 위치 표시 (재조정 중일 때)
+        if (isRepositioning)
+        {
+            Gizmos.color = Color.magenta;
+            Gizmos.DrawWireSphere(targetPosition, 1f);
+            Gizmos.DrawLine(wizardPos, targetPosition);
+        }
+
+        // 현재 플레이어와의 거리 표시
+        Gizmos.color = Color.white;
+        Gizmos.DrawLine(wizardPos, target.position);
+    }
+
+    #endregion
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Wizard_Move.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/Ranged_Types/Enemy_Wizard_Move.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fd1f4890d90a3b140b94ead541ea8093
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/System.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/System.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: af637e96a5e41db458f4c51999b309bd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Base.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Base.cs
@@ -1,0 +1,430 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using Enemy;
+
+[DisallowMultipleComponent]
+public abstract class Enemy_Base : MonoBehaviour
+{
+    [Header("몬스터 기본 정보")]
+    [SerializeField] protected EnemyType enemyType;
+    [SerializeField] protected ElementType elementType;
+    [SerializeField] protected DamageType primaryDamageType; // 주 데미지 타입 (AD/AP)
+    [SerializeField] protected string enemyName = "Enemy";
+
+    [Header("UI 요소")]
+    [SerializeField] protected Slider hpSlider;
+    [SerializeField] protected TextMeshProUGUI hpText;
+    [SerializeField] protected Canvas hpCanvas; // HP바 캔버스
+    [SerializeField] protected TextMeshProUGUI damageText; // 데미지 표시용
+
+    [Header("시각적 효과")]
+    [SerializeField] protected GameObject deathEffect;
+    [SerializeField] protected AudioClip deathSound;
+    [SerializeField] protected GameObject damageEffect; // 피격 이펙트
+
+    // 스탯 시스템
+    protected EnemyStatSystem enemyStats;
+    protected float currentHp;
+    protected bool isDead = false;
+
+    // 플레이어 참조
+    protected Transform playerTransform;
+    protected Player.Player playerScript;
+
+    // 피격 색상 효과
+    protected Renderer enemyRenderer;
+    protected Color originalColor;
+
+    #region Unity Lifecycle
+
+    protected virtual void Awake()
+    {
+        // 스탯 초기화
+        enemyStats = new EnemyStatSystem(enemyType);
+        currentHp = enemyStats.Get(EnemyStatType.MaxHp);
+
+        // 플레이어 찾기
+        GameObject playerObj = GameObject.FindGameObjectWithTag("Player");
+        if (playerObj != null)
+        {
+            playerTransform = playerObj.transform;
+            playerScript = playerObj.GetComponent<Player.Player>();
+        }
+
+        // 렌더러 컴포넌트 (피격 효과용)
+        enemyRenderer = GetComponent<Renderer>();
+        if (enemyRenderer != null)
+        {
+            // 머티리얼 복사해서 원본 보호
+            enemyRenderer.material = new Material(enemyRenderer.material);
+            originalColor = enemyRenderer.material.color;
+        }
+    }
+
+    protected virtual void Start()
+    {
+        InitializeEnemy();
+        UpdateHpUI();
+    }
+
+    protected virtual void Update()
+    {
+        if (!isDead && playerTransform != null)
+        {
+            UpdateBehavior();
+        }
+    }
+
+    #endregion
+
+    #region 초기화
+
+    protected virtual void InitializeEnemy()
+    {
+        // HP 캔버스 설정
+        if (hpCanvas != null)
+        {
+            // World Space Canvas는 카메라 없이도 작동
+            hpCanvas.worldCamera = null;
+            hpCanvas.gameObject.SetActive(false); // 기본적으로 숨김
+        }
+
+        Debug.Log($"{enemyName} ({enemyType}, {elementType}, {primaryDamageType}) 초기화 완료!");
+        LogEnemyStats();
+    }
+
+    protected virtual void LogEnemyStats()
+    {
+        Debug.Log($"=== {enemyName} 스탯 ===");
+        Debug.Log($"HP: {currentHp}");
+        Debug.Log($"물리 공격력: {enemyStats.Get(EnemyStatType.PhysicalDamage)}");
+        Debug.Log($"마법 공격력: {enemyStats.Get(EnemyStatType.MagicalDamage)}");
+        Debug.Log($"물리 방어력: {enemyStats.Get(EnemyStatType.PhysicalDefense)}");
+        Debug.Log($"마법 방어력: {enemyStats.Get(EnemyStatType.MagicalDefense)}");
+        Debug.Log($"이동속도: {enemyStats.Get(EnemyStatType.MoveSpeed)}");
+    }
+
+    #endregion
+
+    #region 추상 메서드 (각 몬스터에서 구현)
+
+    /// <summary>
+    /// 몬스터별 고유 행동 패턴
+    /// </summary>
+    protected abstract void UpdateBehavior();
+
+    /// <summary>
+    /// 몬스터별 공격 패턴
+    /// </summary>
+    protected abstract void PerformAttack();
+
+    /// <summary>
+    /// 몬스터별 이동 패턴
+    /// </summary>
+    protected abstract void UpdateMovement();
+
+    #endregion
+
+    #region 데미지 시스템
+
+    public virtual void TakeDamage(float baseDamage, DamageType damageType = DamageType.Physical, ElementType attackerElement = ElementType.Neutral)
+    {
+        if (isDead) return;
+
+        // 플레이어 스탯 가져오기 (임시로 기본값 사용)
+        Player.PlayerStat tempPlayerStats = new Player.PlayerStat();
+
+        // 데미지 계산기를 사용한 정확한 데미지 계산
+        float actualDamage = DamageCalculator.CalculateDamageToEnemy(
+            tempPlayerStats,
+            attackerElement,
+            damageType,
+            enemyStats,
+            elementType
+        );
+
+        // 만약 플레이어 스크립트가 있다면 실제 스탯 사용
+        if (playerScript != null)
+        {
+            actualDamage = DamageCalculator.CalculateDamageToEnemy(
+                playerScript.GetPlayerStat(),
+                ElementType.Neutral, // 플레이어 속성 (추후 확장 가능)
+                damageType,
+                enemyStats,
+                elementType
+            );
+        }
+
+        // HP 감소
+        currentHp -= actualDamage;
+
+        // 데미지 표시
+        ShowDamageText(actualDamage, damageType);
+
+        Debug.Log($"{enemyName}이 {actualDamage:F1} {damageType} 데미지를 받았습니다! (남은 HP: {currentHp:F1})");
+
+        // HP바 표시
+        ShowHpBar();
+        UpdateHpUI();
+
+        // 피격 효과
+        OnDamaged();
+
+        if (currentHp <= 0)
+        {
+            Die();
+        }
+    }
+
+    protected virtual void OnDamaged()
+    {
+        // 피격 색상 효과
+        StartCoroutine(DamageColorEffect());
+
+        // 피격 이펙트 생성
+        if (damageEffect != null)
+        {
+            GameObject effect = Instantiate(damageEffect, transform.position + Vector3.up, Quaternion.identity);
+            Destroy(effect, 1f);
+        }
+    }
+
+    /// <summary>
+    /// 피격시 색상 변화 효과
+    /// </summary>
+    protected virtual System.Collections.IEnumerator DamageColorEffect()
+    {
+        if (enemyRenderer != null)
+        {
+            // 피격시 빨간색으로 변경
+            enemyRenderer.material.color = Color.red;
+            yield return new WaitForSeconds(0.1f);
+
+            // 원래 색상으로 복구
+            enemyRenderer.material.color = originalColor;
+        }
+    }
+
+    protected virtual void ShowDamageText(float damage, DamageType damageType)
+    {
+        if (damageText != null)
+        {
+            damageText.text = $"-{damage:F0}";
+            damageText.color = Color.white; // 기본 색상으로 고정
+
+            // 데미지 텍스트 애니메이션
+            StartCoroutine(AnimateDamageText());
+        }
+    }
+
+    protected virtual System.Collections.IEnumerator AnimateDamageText()
+    {
+        if (damageText != null)
+        {
+            Vector3 startPos = damageText.transform.position;
+            Vector3 endPos = startPos + Vector3.up * 2f;
+
+            float duration = 1f;
+            float elapsed = 0f;
+
+            damageText.gameObject.SetActive(true);
+
+            while (elapsed < duration)
+            {
+                elapsed += Time.deltaTime;
+                float t = elapsed / duration;
+
+                damageText.transform.position = Vector3.Lerp(startPos, endPos, t);
+                damageText.color = new Color(1f, 1f, 1f, 1f - t); // 페이드 아웃
+
+                yield return null;
+            }
+
+            damageText.gameObject.SetActive(false);
+        }
+    }
+
+    protected virtual void Die()
+    {
+        if (isDead) return;
+
+        isDead = true;
+        
+        // 경험치 지급
+        GiveExperience();
+
+        // 사망 효과
+        PlayDeathEffects();
+
+        // 오브젝트 비활성화 또는 파괴
+        gameObject.SetActive(false);
+    }
+
+    protected virtual void GiveExperience()
+    {
+        if (playerScript != null)
+        {
+            int expReward = GetExperienceReward();
+            playerScript.IncreaseXP(expReward);
+        }
+    }
+
+    protected virtual int GetExperienceReward()
+    {
+        return enemyType switch
+        {
+            EnemyType.MeleeTanker => 15,
+            EnemyType.MeleeAssassin => 20,
+            EnemyType.RangedAD => 18,
+            EnemyType.RangedAP => 25, 
+            EnemyType.MiddleBoss => 100,
+            EnemyType.FinalBoss => 500,
+            _ => 10
+        };
+    }
+
+    #endregion
+
+    #region 공격 시스템
+
+    /// <summary>
+    /// 플레이어에게 데미지를 주는 공통 메서드
+    /// </summary>
+    protected virtual void DealDamageToPlayer(DamageType damageType = DamageType.Physical)
+    {
+        if (playerScript == null) return;
+
+        // 데미지 계산
+        float damage = DamageCalculator.CalculateDamageToPlayer(
+            enemyStats,
+            elementType,
+            damageType,
+            playerScript.GetPlayerStat(),
+            ElementType.Neutral // 플레이어 속성 
+        );
+
+        // 플레이어에게 데미지 적용
+        playerScript.DecreaseHP(damage);
+
+    }
+
+    #endregion
+
+    #region UI 관리
+
+    protected virtual void ShowHpBar()
+    {
+        if (hpCanvas != null)
+        {
+            hpCanvas.gameObject.SetActive(true);
+            // 3초 후 숨기기
+            CancelInvoke(nameof(HideHpBar));
+            Invoke(nameof(HideHpBar), 3f);
+        }
+    }
+
+    protected virtual void HideHpBar()
+    {
+        if (hpCanvas != null)
+        {
+            hpCanvas.gameObject.SetActive(false);
+        }
+    }
+
+    protected virtual void UpdateHpUI()
+    {
+        float maxHp = enemyStats.Get(EnemyStatType.MaxHp);
+
+        if (hpSlider != null)
+        {
+            hpSlider.value = currentHp / maxHp;
+        }
+
+        if (hpText != null)
+        {
+            hpText.text = $"{currentHp:F0} / {maxHp:F0}";
+        }
+    }
+
+    #endregion
+
+    #region 유틸리티 메서드
+
+    protected virtual void PlayDeathEffects()
+    {
+        // 사망 이펙트
+        if (deathEffect != null)
+        {
+            Instantiate(deathEffect, transform.position, Quaternion.identity);
+        }
+
+        // 사망 사운드
+        if (deathSound != null)
+        {
+            AudioSource.PlayClipAtPoint(deathSound, transform.position);
+        }
+    }
+
+    protected virtual float GetDistanceToPlayer()
+    {
+        if (playerTransform != null)
+        {
+            return Vector3.Distance(transform.position, playerTransform.position);
+        }
+        return float.MaxValue;
+    }
+
+    protected virtual bool IsPlayerInRange(float range)
+    {
+        return GetDistanceToPlayer() <= range;
+    }
+
+    protected virtual bool IsPlayerInAttackRange()
+    {
+        return IsPlayerInRange(enemyStats.Get(EnemyStatType.AttackRange));
+    }
+
+    protected virtual bool IsPlayerInDetectionRange()
+    {
+        return IsPlayerInRange(enemyStats.Get(EnemyStatType.DetectionRange));
+    }
+
+    #endregion
+
+    #region 충돌 처리
+
+    protected virtual void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Attack"))
+        {
+            other.gameObject.SetActive(false);
+
+            // 플레이어 공격은 기본적으로 물리 데미지로 처리
+            TakeDamage(10f, DamageType.Physical, ElementType.Neutral);
+        }
+    }
+
+    #endregion
+
+    #region 퍼블릭 접근자
+
+    public EnemyType GetEnemyType() => enemyType;
+    public ElementType GetElementType() => elementType;
+    public DamageType GetPrimaryDamageType() => primaryDamageType;
+    public EnemyStatSystem GetEnemyStats() => enemyStats;
+    public float GetCurrentHp() => currentHp;
+    public bool IsDead() => isDead;
+
+    /// <summary>
+    /// 주 데미지 타입에 따른 공격력 반환
+    /// </summary>
+    public float GetMainDamage()
+    {
+        return primaryDamageType == DamageType.Physical
+            ? enemyStats.Get(EnemyStatType.PhysicalDamage)
+            : enemyStats.Get(EnemyStatType.MagicalDamage);
+    }
+
+    #endregion
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Base.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Base.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3137aed559ce7a64695a81872073348d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Stat_System.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Stat_System.cs
@@ -1,0 +1,273 @@
+// Unity
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using System.Collections.Generic;
+
+namespace Enemy
+{
+    /// <summary>
+    /// 몬스터 스탯 타입 정의
+    /// </summary>
+    public enum EnemyStatType
+    {
+        MaxHp,
+        PhysicalDamage,     // AD (물리 데미지)
+        MagicalDamage,      // AP (마법 데미지)
+        AttackSpeed,
+        MoveSpeed,
+        PhysicalDefense,    // 물리 방어력
+        MagicalDefense,     // 마법 방어력
+        AttackRange,
+        DetectionRange
+    }
+
+    /// <summary>
+    /// 몬스터 종류 정의
+    /// </summary>
+    public enum EnemyType
+    {
+        MeleeTanker,    // 근접 탱커형 (AD)
+        MeleeAssassin,  // 근접 어쌔신형 (AD)
+        RangedAD,       // 원거리 AD형 (물리)
+        RangedAP,       // 원거리 AP형 (마법)
+        MiddleBoss,     // 중간보스 (혼합)
+        FinalBoss       // 최종보스 (혼합)
+    }
+
+    /// <summary>
+    /// 속성 타입 정의
+    /// </summary>
+    public enum ElementType
+    {
+        Light,  // 빛
+        Dark,   // 어둠
+        Neutral // 무속성
+    }
+
+    /// <summary>
+    /// 데미지 타입 정의
+    /// </summary>
+    public enum DamageType
+    {
+        Physical,   // 물리 데미지 (AD)
+        Magical     // 마법 데미지 (AP)
+    }
+
+    /// <summary>
+    /// 기본 스탯 클래스 
+    /// </summary>
+    [System.Serializable]
+    public class EnemyStat
+    {
+        public float Base { get; private set; }
+        public float Bonus { get; private set; }
+
+        public float Total => Base + Bonus;
+
+        public EnemyStat(float baseValue)
+        {
+            Base = baseValue;
+            Bonus = 0f;
+        }
+
+        public void SetBase(float value) => Base = value;
+        public void AddBonus(float value) => Bonus += value;
+        public void ResetBonus() => Bonus = 0f;
+    }
+
+    /// <summary>
+    /// 몬스터 전체 스탯 관리 클래스
+    /// </summary>
+    [System.Serializable]
+    public class EnemyStatSystem
+    {
+        private Dictionary<EnemyStatType, EnemyStat> stats = new();
+
+        public EnemyStatSystem(EnemyType enemyType)
+        {
+            InitializeStats(enemyType);
+        }
+
+        private void InitializeStats(EnemyType enemyType)
+        {
+            switch (enemyType)
+            {
+                case EnemyType.MeleeTanker:
+                    stats[EnemyStatType.MaxHp] = new EnemyStat(150f);
+                    stats[EnemyStatType.PhysicalDamage] = new EnemyStat(25f);
+                    stats[EnemyStatType.MagicalDamage] = new EnemyStat(0f);
+                    stats[EnemyStatType.AttackSpeed] = new EnemyStat(0.8f);
+                    stats[EnemyStatType.MoveSpeed] = new EnemyStat(1.5f);
+                    stats[EnemyStatType.PhysicalDefense] = new EnemyStat(15f);
+                    stats[EnemyStatType.MagicalDefense] = new EnemyStat(5f);
+                    stats[EnemyStatType.AttackRange] = new EnemyStat(1.5f);
+                    stats[EnemyStatType.DetectionRange] = new EnemyStat(8f);
+                    break;
+
+                case EnemyType.MeleeAssassin:
+                    stats[EnemyStatType.MaxHp] = new EnemyStat(80f);
+                    stats[EnemyStatType.PhysicalDamage] = new EnemyStat(45f);
+                    stats[EnemyStatType.MagicalDamage] = new EnemyStat(0f);
+                    stats[EnemyStatType.AttackSpeed] = new EnemyStat(1.5f);
+                    stats[EnemyStatType.MoveSpeed] = new EnemyStat(3f);
+                    stats[EnemyStatType.PhysicalDefense] = new EnemyStat(3f);
+                    stats[EnemyStatType.MagicalDefense] = new EnemyStat(8f);
+                    stats[EnemyStatType.AttackRange] = new EnemyStat(1.2f);
+                    stats[EnemyStatType.DetectionRange] = new EnemyStat(12f);
+                    break;
+
+                case EnemyType.RangedAD:
+                    stats[EnemyStatType.MaxHp] = new EnemyStat(60f);
+                    stats[EnemyStatType.PhysicalDamage] = new EnemyStat(35f);
+                    stats[EnemyStatType.MagicalDamage] = new EnemyStat(0f);
+                    stats[EnemyStatType.AttackSpeed] = new EnemyStat(1.2f);
+                    stats[EnemyStatType.MoveSpeed] = new EnemyStat(2f);
+                    stats[EnemyStatType.PhysicalDefense] = new EnemyStat(2f);
+                    stats[EnemyStatType.MagicalDefense] = new EnemyStat(5f);
+                    stats[EnemyStatType.AttackRange] = new EnemyStat(8f);
+                    stats[EnemyStatType.DetectionRange] = new EnemyStat(10f);
+                    break;
+
+                case EnemyType.RangedAP:
+                    stats[EnemyStatType.MaxHp] = new EnemyStat(70f);
+                    stats[EnemyStatType.PhysicalDamage] = new EnemyStat(0f);
+                    stats[EnemyStatType.MagicalDamage] = new EnemyStat(50f);
+                    stats[EnemyStatType.AttackSpeed] = new EnemyStat(0.8f);
+                    stats[EnemyStatType.MoveSpeed] = new EnemyStat(1.8f);
+                    stats[EnemyStatType.PhysicalDefense] = new EnemyStat(1f);
+                    stats[EnemyStatType.MagicalDefense] = new EnemyStat(15f);
+                    stats[EnemyStatType.AttackRange] = new EnemyStat(10f);
+                    stats[EnemyStatType.DetectionRange] = new EnemyStat(12f);
+                    break;
+
+                case EnemyType.MiddleBoss:
+                    stats[EnemyStatType.MaxHp] = new EnemyStat(500f);
+                    stats[EnemyStatType.PhysicalDamage] = new EnemyStat(40f);
+                    stats[EnemyStatType.MagicalDamage] = new EnemyStat(40f);
+                    stats[EnemyStatType.AttackSpeed] = new EnemyStat(0.6f);
+                    stats[EnemyStatType.MoveSpeed] = new EnemyStat(1.2f);
+                    stats[EnemyStatType.PhysicalDefense] = new EnemyStat(20f);
+                    stats[EnemyStatType.MagicalDefense] = new EnemyStat(20f);
+                    stats[EnemyStatType.AttackRange] = new EnemyStat(6f);
+                    stats[EnemyStatType.DetectionRange] = new EnemyStat(15f);
+                    break;
+
+                case EnemyType.FinalBoss:
+                    stats[EnemyStatType.MaxHp] = new EnemyStat(2000f);
+                    stats[EnemyStatType.PhysicalDamage] = new EnemyStat(70f);
+                    stats[EnemyStatType.MagicalDamage] = new EnemyStat(80f);
+                    stats[EnemyStatType.AttackSpeed] = new EnemyStat(0.4f);
+                    stats[EnemyStatType.MoveSpeed] = new EnemyStat(1f);
+                    stats[EnemyStatType.PhysicalDefense] = new EnemyStat(35f);
+                    stats[EnemyStatType.MagicalDefense] = new EnemyStat(35f);
+                    stats[EnemyStatType.AttackRange] = new EnemyStat(8f);
+                    stats[EnemyStatType.DetectionRange] = new EnemyStat(20f);
+                    break;
+            }
+        }
+
+        public float Get(EnemyStatType type) => stats.ContainsKey(type) ? stats[type].Total : 0f;
+        public void SetBase(EnemyStatType type, float value) => stats[type].SetBase(value);
+        public void AddBonus(EnemyStatType type, float value) => stats[type].AddBonus(value);
+        public void ResetBonus(EnemyStatType type) => stats[type].ResetBonus();
+        public void ResetAllBonus()
+        {
+            foreach (var stat in stats.Values)
+                stat.ResetBonus();
+        }
+    }
+
+    /// <summary>
+    /// 데미지 계산 시스템
+    /// </summary>
+    public static class DamageCalculator
+    {
+        /// <summary>
+        /// 몬스터가 플레이어에게 주는 데미지 계산
+        /// </summary>
+        public static float CalculateDamageToPlayer(
+            EnemyStatSystem attackerStats,
+            ElementType attackerElement,
+            DamageType damageType,
+            Player.PlayerStat playerStats,
+            ElementType playerElement = ElementType.Neutral)
+        {
+            // 1. 기본 데미지 가져오기
+            float baseDamage = damageType == DamageType.Physical
+                ? attackerStats.Get(EnemyStatType.PhysicalDamage)
+                : attackerStats.Get(EnemyStatType.MagicalDamage);
+
+            // 2. 플레이어 방어력 가져오기 (플레이어 스탯에서)
+            float playerDefense = damageType == DamageType.Physical
+                ? playerStats.Get(Player.StatType.DefensivePower) // 물리 방어력
+                : playerStats.Get(Player.StatType.DefensivePower) * 0.8f; // 마법 방어력 (임시)
+
+            // 3. 속성 상성 계산
+            float elementMultiplier = CalculateElementalMultiplier(attackerElement, playerElement);
+
+            // 4. 데미지 타입별 추가 계산
+            float typeMultiplier = damageType == DamageType.Magical ? 1.1f : 1.0f; // 마법이 약간 더 강함
+
+            // 5. 최종 데미지 계산
+            float finalDamage = (baseDamage * elementMultiplier * typeMultiplier) - playerDefense;
+
+            // 6. 최소 데미지 보장
+            return Mathf.Max(1f, finalDamage);
+        }
+
+        /// <summary>
+        /// 플레이어가 몬스터에게 주는 데미지 계산
+        /// </summary>
+        public static float CalculateDamageToEnemy(
+            Player.PlayerStat playerStats,
+            ElementType playerElement,
+            DamageType damageType,
+            EnemyStatSystem enemyStats,
+            ElementType enemyElement)
+        {
+            // 1. 플레이어 기본 데미지
+            float baseDamage = playerStats.Get(Player.StatType.AttackDamage);
+
+            // 2. 몬스터 방어력
+            float enemyDefense = damageType == DamageType.Physical
+                ? enemyStats.Get(EnemyStatType.PhysicalDefense)
+                : enemyStats.Get(EnemyStatType.MagicalDefense);
+
+            // 3. 속성 상성 계산
+            float elementMultiplier = CalculateElementalMultiplier(playerElement, enemyElement);
+
+            // 4. 최종 데미지 계산
+            float finalDamage = (baseDamage * elementMultiplier) - enemyDefense;
+
+            // 5. 최소 데미지 보장
+            return Mathf.Max(1f, finalDamage);
+        }
+
+        /// <summary>
+        /// 속성 상성 배율 계산
+        /// </summary>
+        private static float CalculateElementalMultiplier(ElementType attackerElement, ElementType defenderElement)
+        {
+            // 빛 vs 어둠 상성
+            if (attackerElement == ElementType.Light && defenderElement == ElementType.Dark)
+            {
+                return 1.5f; // 빛이 어둠에게 1.5배 데미지
+            }
+            else if (attackerElement == ElementType.Dark && defenderElement == ElementType.Light)
+            {
+                return 1.5f; // 어둠이 빛에게 1.5배 데미지
+            }
+            else if (attackerElement == defenderElement && attackerElement != ElementType.Neutral)
+            {
+                return 0.7f; // 같은 속성끼리는 0.7배 데미지
+            }
+            else if (attackerElement == ElementType.Neutral || defenderElement == ElementType.Neutral)
+            {
+                return 1.0f; // 무속성은 기본 데미지
+            }
+
+            return 1.0f; // 기본 배율
+        }
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Stat_System.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Stat_System.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c4d96e57b0e75a44b326c2acb270e61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Temp_Damage_Projectile.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Temp_Damage_Projectile.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using System.Collections;
+
+/// <summary>
+/// 임시 데미지 처리 컴포넌트 - 보스 공격 시스템에서 공통 사용
+/// </summary>
+public class Enemy_Temp_Damage_Projectile : MonoBehaviour
+{
+    [Header("데미지 설정")]
+    public float damage = 50f;
+    public string projectileType = "공격";
+    public bool continuousDamage = false; // 지속 데미지 여부
+
+    private float lastDamageTime = 0f;
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            DealDamage(other);
+        }
+    }
+
+    private void OnTriggerStay(Collider other)
+    {
+        if (continuousDamage && other.CompareTag("Player"))
+        {
+            // 0.3초마다 지속 데미지
+            if (Time.time - lastDamageTime >= 0.3f)
+            {
+                DealDamage(other);
+                lastDamageTime = Time.time;
+            }
+        }
+    }
+
+    private void DealDamage(Collider playerCollider)
+    {
+        Player.Player playerScript = playerCollider.GetComponent<Player.Player>();
+        if (playerScript != null)
+        {
+            playerScript.DecreaseHP(damage);
+            Debug.Log($"{projectileType} 적중! {damage} 데미지!");
+        }
+    }
+
+    /// <summary>
+    /// 데미지 설정 초기화
+    /// </summary>
+    public void Initialize(float damageAmount, string attackType, bool isContinuous = false)
+    {
+        damage = damageAmount;
+        projectileType = attackType;
+        continuousDamage = isContinuous;
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Temp_Damage_Projectile.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Temp_Damage_Projectile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06d77c8de9ce67e46ba01fb3495bc302
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Temp_Follow_Boss.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Temp_Follow_Boss.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+/// <summary>
+/// 임시 보스 따라다니기 컴포넌트 - 어둠 장판 등에서 사용
+/// </summary>
+public class Enemy_Temp_Follow_Boss : MonoBehaviour
+{
+    [Header("따라다니기 설정")]
+    public Transform target;
+    public float followSpeed = 2f;
+    public float yOffset = 0.05f; // 지면에 붙이기 위한 Y 오프셋
+
+    private void Update()
+    {
+        if (target != null)
+        {
+            Vector3 targetPos = target.position;
+            targetPos.y = yOffset; // 지면에 붙이기
+
+            transform.position = Vector3.Lerp(transform.position, targetPos,
+                followSpeed * Time.deltaTime);
+        }
+    }
+
+    /// <summary>
+    /// 따라다닐 대상과 속도 설정
+    /// </summary>
+    public void Initialize(Transform targetTransform, float speed = 2f, float yPos = 0.05f)
+    {
+        target = targetTransform;
+        followSpeed = speed;
+        yOffset = yPos;
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Temp_Follow_Boss.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Temp_Follow_Boss.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b177f56732feb1e4fbaddb0ca9459a98
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Temp_Orb_Health.cs
+++ b/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Temp_Orb_Health.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+using System.Collections;
+
+/// <summary>
+/// 임시 구체 체력 시스템 - 프리팹이 없을 때 사용
+/// </summary>
+public class Enemy_Temp_Orb_Health : MonoBehaviour
+{
+    private Enemy_Final_Boss_Neutral boss;
+    private float health;
+    private bool isLightOrb;
+
+    public void Initialize(Enemy_Final_Boss_Neutral ownerBoss, float orbHealth, bool lightOrb)
+    {
+        boss = ownerBoss;
+        health = orbHealth;
+        isLightOrb = lightOrb;
+
+        Collider collider = GetComponent<Collider>();
+        if (collider != null)
+            collider.isTrigger = true;
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("PlayerAttack") || other.CompareTag("Projectile") || other.CompareTag("Player"))
+        {
+            TakeDamage(50f);
+        }
+    }
+
+    public void TakeDamage(float damage)
+    {
+        health -= damage;
+        StartCoroutine(HitEffect());
+
+        if (health <= 0)
+        {
+            if (boss != null)
+            {
+                if (isLightOrb)
+                    boss.OnLightOrbDestroyed();
+                else
+                    boss.OnDarkOrbDestroyed();
+            }
+            Destroy(gameObject);
+        }
+    }
+
+    private IEnumerator HitEffect()
+    {
+        Renderer renderer = GetComponent<Renderer>();
+        if (renderer != null)
+        {
+            Color originalColor = renderer.material.color;
+            renderer.material.color = Color.white;
+            yield return new WaitForSeconds(0.1f);
+            renderer.material.color = originalColor;
+        }
+    }
+}

--- a/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Temp_Orb_Health.cs.meta
+++ b/Lunebris/Assets/Scripts/06. Enemy/System/Enemy_Temp_Orb_Health.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39a91b0a6d535b2428a746b26a2b6da3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lunebris/UpgradeLog.htm
+++ b/Lunebris/UpgradeLog.htm
@@ -1,0 +1,273 @@
+﻿<!DOCTYPE html>
+<!-- saved from url=(0014)about:internet -->
+ <html xmlns:msxsl="urn:schemas-microsoft-com:xslt"><head><meta content="en-us" http-equiv="Content-Language" /><meta content="text/html; charset=utf-16" http-equiv="Content-Type" /><title _locID="ConversionReport0">
+          마이그레이션 보고서
+        </title><style> 
+                    /* Body style, for the entire document */
+                    body
+                    {
+                        background: #F3F3F4;
+                        color: #1E1E1F;
+                        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+                        padding: 0;
+                        margin: 0;
+                    }
+
+                    /* Header1 style, used for the main title */
+                    h1
+                    {
+                        padding: 10px 0px 10px 10px;
+                        font-size: 21pt;
+                        background-color: #E2E2E2;
+                        border-bottom: 1px #C1C1C2 solid; 
+                        color: #201F20;
+                        margin: 0;
+                        font-weight: normal;
+                    }
+
+                    /* Header2 style, used for "Overview" and other sections */
+                    h2
+                    {
+                        font-size: 18pt;
+                        font-weight: normal;
+                        padding: 15px 0 5px 0;
+                        margin: 0;
+                    }
+
+                    /* Header3 style, used for sub-sections, such as project name */
+                    h3
+                    {
+                        font-weight: normal;
+                        font-size: 15pt;
+                        margin: 0;
+                        padding: 15px 0 5px 0;
+                        background-color: transparent;
+                    }
+
+                    /* Color all hyperlinks one color */
+                    a
+                    {
+                        color: #1382CE;
+                    }
+
+                    /* Table styles */ 
+                    table
+                    {
+                        border-spacing: 0 0;
+                        border-collapse: collapse;
+                        font-size: 10pt;
+                    }
+
+                    table th
+                    {
+                        background: #E7E7E8;
+                        text-align: left;
+                        text-decoration: none;
+                        font-weight: normal;
+                        padding: 3px 6px 3px 6px;
+                    }
+
+                    table td
+                    {
+                        vertical-align: top;
+                        padding: 3px 6px 5px 5px;
+                        margin: 0px;
+                        border: 1px solid #E7E7E8;
+                        background: #F7F7F8;
+                    }
+
+                    /* Local link is a style for hyperlinks that link to file:/// content, there are lots so color them as 'normal' text until the user mouse overs */
+                    .localLink
+                    {
+                        color: #1E1E1F;
+                        background: #EEEEED;
+                        text-decoration: none;
+                    }
+
+                    .localLink:hover
+                    {
+                        color: #1382CE;
+                        background: #FFFF99;
+                        text-decoration: none;
+                    }
+
+                    /* Center text, used in the over views cells that contain message level counts */ 
+                    .textCentered
+                    {
+                        text-align: center;
+                    }
+
+                    /* The message cells in message tables should take up all avaliable space */
+                    .messageCell
+                    {
+                        width: 100%;
+                    }
+
+                    /* Padding around the content after the h1 */ 
+                    #content 
+                    {
+	                    padding: 0px 12px 12px 12px; 
+                    }
+
+                    /* The overview table expands to width, with a max width of 97% */ 
+                    #overview table
+                    {
+                        width: auto;
+                        max-width: 75%; 
+                    }
+
+                    /* The messages tables are always 97% width */
+                    #messages table
+                    {
+                        width: 97%;
+                    }
+
+                    /* All Icons */
+                    .IconSuccessEncoded, .IconInfoEncoded, .IconWarningEncoded, .IconErrorEncoded
+                    {
+                        min-width:18px;
+                        min-height:18px; 
+                        background-repeat:no-repeat;
+                        background-position:center;
+                    }
+
+                    /* Success icon encoded */
+                    .IconSuccessEncoded
+                    {
+                        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+                        /* [---XsltValidateInternal-Base64EncodedImage:IconSuccess#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+                        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAA7EAAAOxAGVKw4bAAABcElEQVR4Xq2TsUsCURzHv15g8ZJcBWlyiYYgCIWcb9DFRRwMW5TA2c0/QEFwFkxxUQdxVlBwCYWOi6IhWgQhBLHJUCkhLr/BW8S7gvrAg+N+v8/v+x68Z8MGy+XSCyABQAXgBgHGALoASkIIDWSLeLBetdHryMjd5IxQPWT4rn1c/P7+xxp72Cs9m5SZ0Bq2vPnbPFafK2zDvmNHypdC0BPkLlQhxJsCAhQoZwdZU5mwxh720qGo8MzTxTTKZDPCx2HoVzp6lz0Q9tKhyx0kGs8Ny+TkWRKk8lCROwEduhyg9l/6lunOPSfmH3NUH6uQ0KHLAe7JYvJjevm+DAMGJHToKtigE+vwvIidxLamb8IBY9e+C5LiXREkfho3TSd06HJA13/oh6T51MTsfQbHrsMynQ5dDihFjiK8JJAU9AKIWTp76dCVN7HWHrajmUEGvyF9nkbAE6gLIS7kTUyuf2gscLoJrElZo/Mvj+nPz/kLTmfnEwP3tB0AAAAASUVORK5CYII=);
+                    }
+
+                    /* Information icon encoded */
+                    .IconInfoEncoded
+                    {
+                        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+                        /* [---XsltValidateInternal-Base64EncodedImage:IconInformation#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+                        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABHElEQVR4Xs2TsUoDQRRF7wwoziokjZUKadInhdhukR9YP8DMX1hYW+QvdsXa/QHBbcXC7W0CamWTQnclFutceIQJwwaWNLlwm5k5d94M76mmaeCrrmsLYOocY12FcxZFUeozCqKqqgYA8uevv1H6VuPxcwlfk5N92KHBxfFeCSAxxswlYAW/Xr989x/mv9gkhtyMDhcAxgzRsp7flj8B/HF1RsMXq+NZMkopaHe7lbKxQUEIGbKsYNoGn969060hZBkQex/W8oRQwsQaW2o3Ago2SVcJUzAgY3N0lTCZZm+zPS8HB51gMmS1DEYyOz9acKO1D8JWTlafKIMxdhvlfdyT94Vv5h7P8Ky7nQzACmhvKq3zk3PjW9asz9D/1oigecsioooAAAAASUVORK5CYII=);
+                    }
+
+                    /* Warning icon encoded */
+                    .IconWarningEncoded
+                    {
+                        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+                        /* [---XsltValidateInternal-Base64EncodedImage:IconWarning#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+                        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAx0lEQVR4XpWSMQ7CMAxFf4xAyBMLCxMrO8dhaBcuwdCJS3RJBw7SA/QGTCxdWJgiQYWKXJWKIXHIlyw5lqr34tQgEOdcBsCOx5yZK3hCCKdYXneQkh4pEfqzLfu+wVDSyyzFoJjfz9NB+pAF+eizx2Vruts0k15mPgvS6GYvpVtQhB61IB/dk6AF6fS4Ben0uIX5odtFe8Q/eW1KvFeH4e8khT6+gm5B+t3juyDt7n0jpe+CANTd+oTUjN/U3yVaABnSUjFz/gFq44JaVSCXeQAAAABJRU5ErkJggg==);
+                    }
+
+                    /* Error icon encoded */
+                    .IconErrorEncoded
+                    {
+                        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+                        /* [---XsltValidateInternal-Base64EncodedImage:IconError#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+                        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABQElEQVR4XqWTvUoEQRCE6wYPZUA80AfwAQz23uCMjA7MDRQEIzPBVEyNTQUFIw00vcQTTMzuAh/AxEQQT8HF/3G/oGGnEUGuoNnd6qoZuqltyKEsyzVJq5I6rnUp6SjGeGhESikzzlc1eL7opfuVbrqbU1Zw9NCgtQMaZpY0eNnaaL2fHusvTK5vKu7sjSS1Y4y3QUA6K3e3Mau5UFDyMP7tYF9o8cAHZv68vipoIJg971PZIZ5HiwdvYGGvFVFHmGmZ2MxwmQYPXubPl9Up0tfoMQGetXd6mRbvhBw+boZ6WF7Mbv1+GsHRk0fQmPAH1GfmZirbCfDJ61tw3Px8/8pZsPAG4jlVhcPgZ7adwNWBB68lkRQWFiTgFlbnLY3DGGM7izIJIyT/jjIvEJw6fdJTc6krDzh6aMwMP9bvDH4ADSsa9uSWVJkAAAAASUVORK5CYII=);
+                    }
+                 </style><script type="text/javascript" language="javascript"> 
+          
+            // Startup 
+            // Hook up the the loaded event for the document/window, to linkify the document content
+            var startupFunction = function() { linkifyElement("messages"); };
+            
+            if(window.attachEvent)
+            {
+              window.attachEvent('onload', startupFunction);
+            }
+            else if (window.addEventListener) 
+            {
+              window.addEventListener('load', startupFunction, false);
+            }
+            else 
+            {
+              document.addEventListener('load', startupFunction, false);
+            } 
+            
+            // Toggles the visibility of table rows with the specified name 
+            function toggleTableRowsByName(name)
+            {
+               var allRows = document.getElementsByTagName('tr');
+               for (i=0; i < allRows.length; i++)
+               {
+                  var currentName = allRows[i].getAttribute('name');
+                  if(!!currentName && currentName.indexOf(name) == 0)
+                  {
+                      var isVisible = allRows[i].style.display == ''; 
+                      isVisible ? allRows[i].style.display = 'none' : allRows[i].style.display = '';
+                  }
+               }
+            }
+            
+            function scrollToFirstVisibleRow(name) 
+            {
+               var allRows = document.getElementsByTagName('tr');
+               for (i=0; i < allRows.length; i++)
+               {
+                  var currentName = allRows[i].getAttribute('name');
+                  var isVisible = allRows[i].style.display == ''; 
+                  if(!!currentName && currentName.indexOf(name) == 0 && isVisible)
+                  {
+                     allRows[i].scrollIntoView(true); 
+                     return true; 
+                  }
+               }
+               
+               return false;
+            }
+            
+            // Linkifies the specified text content, replaces candidate links with html links 
+            function linkify(text)
+            {
+                 if(!text || 0 === text.length)
+                 {
+                     return text; 
+                 }
+
+                 // Find http, https and ftp links and replace them with hyper links 
+                 var urlLink = /(http|https|ftp)\:\/\/[a-zA-Z0-9\-\.]+(:[a-zA-Z0-9]*)?\/?([a-zA-Z0-9\-\._\?\,\/\\\+&%\$#\=~;\{\}])*/gi;
+                 
+                 return text.replace(urlLink, '<a href="$&">$&</a>') ;
+            }
+            
+            // Linkifies the specified element by ID
+            function linkifyElement(id)
+            {
+                var element = document.getElementById(id);
+                if(!!element)
+                {
+                  element.innerHTML = linkify(element.innerHTML); 
+                }
+            }
+            
+            function ToggleMessageVisibility(projectName)
+            {
+              if(!projectName || 0 === projectName.length)
+              {
+                return; 
+              }
+              
+              toggleTableRowsByName("MessageRowClass" + projectName);
+              toggleTableRowsByName('MessageRowHeaderShow' + projectName);
+              toggleTableRowsByName('MessageRowHeaderHide' + projectName); 
+            }
+            
+            function ScrollToFirstVisibleMessage(projectName)
+            {
+              if(!projectName || 0 === projectName.length)
+              {
+                return; 
+              }
+              
+              // First try the 'Show messages' row
+              if(!scrollToFirstVisibleRow('MessageRowHeaderShow' + projectName))
+              {
+                // Failed to find a visible row for 'Show messages', try an actual message row 
+                scrollToFirstVisibleRow('MessageRowClass' + projectName); 
+              }
+            }
+           </script></head><body><h1 _locID="ConversionReport">
+          마이그레이션 보고서 - </h1><div id="content"><h2 _locID="OverviewTitle">개요</h2><div id="overview"><table><tr><th></th><th _locID="ProjectTableHeader">프로젝트</th><th _locID="PathTableHeader">경로</th><th _locID="ErrorsTableHeader">오류</th><th _locID="WarningsTableHeader">경고</th><th _locID="MessagesTableHeader">메시지</th></tr><tr><td class="IconErrorEncoded" /><td><strong><a href="#Assembly-CSharp">Assembly-CSharp</a></strong></td><td>Assembly-CSharp.csproj</td><td class="textCentered"><a href="#Assembly-CSharpError">1</a></td><td class="textCentered"><a>0</a></td><td class="textCentered"><a href="#">0</a></td></tr><tr><td class="IconSuccessEncoded" /><td><strong><a href="#Solution"><span _locID="OverviewSolutionSpan">솔루션</span></a></strong></td><td>Lunebris.sln</td><td class="textCentered"><a>0</a></td><td class="textCentered"><a>0</a></td><td class="textCentered"><a href="#" onclick="ScrollToFirstVisibleMessage('Solution'); return false;">1</a></td></tr></table></div><h2 _locID="SolutionAndProjectsTitle">솔루션 및 프로젝트</h2><div id="messages"><a name="Assembly-CSharp" /><h3>Assembly-CSharp</h3><table><tr id="Assembly-CSharpHeaderRow"><th></th><th class="messageCell" _locID="MessageTableHeader">메시지</th></tr><tr name="ErrorRowClassAssembly-CSharp"><td class="IconErrorEncoded"><a name="Assembly-CSharpError" /></td><td class="messageCell"><strong>Assembly-CSharp.csproj:
+        </strong><span>이 프로젝트 형식을 기반으로 하는 애플리케이션을 찾지 못했습니다. 추가 정보를 보려면 이 링크를 확인하십시오. http://go.microsoft.com/fwlink/?LinkID=299083&amp;projecttype=E097FAD1-6243-4DAD-9C02-E9B9EFC3FFC1</span></td></tr></table><a name="Solution" /><h3 _locID="ProjectDisplayNameHeader">솔루션</h3><table><tr id="SolutionHeaderRow"><th></th><th class="messageCell" _locID="MessageTableHeader">메시지</th></tr><tr name="MessageRowHeaderShowSolution"><td class="IconInfoEncoded" /><td class="messageCell"><a _locID="ShowAdditionalMessages" href="#" name="SolutionMessage" onclick="ToggleMessageVisibility('Solution'); return false;">
+          표시 1 추가 메시지
+        </a></td></tr><tr name="MessageRowClassSolution" style="display: none"><td class="IconInfoEncoded"><a name="SolutionMessage" /></td><td class="messageCell"><strong>Lunebris.sln:
+        </strong><span>솔루션 파일은 마이그레이션하지 않아도 됩니다.</span></td></tr><tr style="display: none" name="MessageRowHeaderHideSolution"><td class="IconInfoEncoded" /><td class="messageCell"><a _locID="HideAdditionalMessages" href="#" name="SolutionMessage" onclick="ToggleMessageVisibility('Solution'); return false;">
+          숨기기 1 추가 메시지
+        </a></td></tr></table></div></div></body></html>


### PR DESCRIPTION
  <br/>

## 🔎 작업 내용

- 기존 Enemy스크립트가  제가 만든 Enemy 관련 스크립트랑 달라서 오류가 납니다. 근데 충돌이 일어난다고 해서 기존 스크립트와 프리팹을 수정이나 삭제하지 않고 그냥 올렸습니다. 기존 Enemy 스크립트, Enemy move스크립트, 프리팹을 지우면 오류가 없어질 것입니다.

- Prefebs - Enemy에 프리팹을 올려두었습니다.
Enemy_Object에는 일반 몹과 중간 보스 최종 보스 프리팹을 넣어 두었습니다.
실험할 때 원하는 몹을 하이어라키 창에 올려두고 실행하면  됩니다.
Enemy_Projectiles에는 일반 몹, 중간 보스, 최종 보스가 사용하는 탄막이나 장판, 광선을 넣어두었습니다. 안에 중간 보스와 최종 보스 파일이 따로 있습니다.
Enemy_UI에서는 몹의 체력을 구현했습니다.

- Scripts - Enemy에서 스크립트 작업을 했습니다. Boss에는 최종 보스와 중간 보스에 관한 스크립트가 있습니다. Melee_Types에서는 근거리 일반 몹에 관한 스크립트가 있고 Ranged_Types에서는 원거리 일반 몹에 관한 스크립트가 있습니다. Projectiles에는 몹이 사용하는 탄막이나 광선, 장판에 관한 스크립트가 있습니다. System에는 시스템에 관한 스크립트들이 있습니다.

- feat:(기본 몹)
기본 몹 관련 스크립트를 추가했습니다. ap딜러, ad딜러, 탱커, 어쌔신이 있습니다.

ap딜러: 원거리에서 유도 미사일을 날립니다. 유도력을 조정 가능합니다.

ad딜러: 원거리에서 일반 탄막을 날립니다.

탱커: 그냥 느린 몹입니다.

어쌔신: 그냥 빠른 몹입니다.

모두 본체 스크립트와 move 스크립트를 분리해 놓았습니다.

기본 몹이 쓰는 프리팹을 추가했습니다. ap 탄막, ad 탄막이 있습니다.

기본 몹이 쓰는 HP UI를 구현하여 적용했습니다.  각 몬스터 머리 위에 뜨게 하였고 플레이어에게 맞으면 활성화 됩니다.

- feat:(중간 보스)

중간 보스 관련 스크립트를 추가했습니다.

Enemy_Middle_Boss: 그랩, 탄막, 장판을 이용하는 몹(어둠)이 있습니다.

Enemy_Middle_Boss2: 대쉬 후 탄막 공격, 광선 발사하는 몹(빛)이 있습니다.

중간 보스가 쓰는 프리팹 추가했습니다. 탄막, 광선, 장판, 그랩 탄막이 있습니다.

보스 몹 HP UI를 구현하여 적용했습니다. 화면 위쪽에 뜨게 하였습니다.

- feat: (최종 보스)
최종 보스 관련 스크립트를 추가했습니다. 최종보스는 3가지 모드로 중립 모드, 빛 모드, 어둠 모드가 있습니다.

중립모드: 오브를 생성하여 공격 하도록 합니다. 이 상태에서 보스는 그냥 플레이어를 지켜봅니다. 한 오브가 죽으면 반대 타입의 모드로 전환하여 플레이어를 공격합니다.

오브: 빛 오브와 어둠 오브가 있습니다. 한 오브가 죽으면 다른 오브도 죽으며 보스가 2페이즈에 돌입합니다.

빛 오브: 빠르게 움직이면서 플레이어를 향해 광선을 발사합니다.  죽으면 사방으로 광선을 발사하며 중립 보스는 어둠 모드로 들어갑니다.

어둠 오브: 천천히 움직이며 탄막으로 플레이어를 공격합니다. 죽으면 사방으로 탄막을 발사하며  중립 보스는 빛 모드로 들어갑니다.

빛 모드: 광선과 검기를 난사하며 플레이어를 공격합니다. 경고 이펙트와 함께 빛 기둥이 내려와 주변에 지속적으로 데미지를 입힙니다.

어둠모드: 주변에 지속 데미지를 주는 장판을 생성합니다. 다양한 패턴의 탄막을 구사하여 플레이어를 공격하고 플레이어의 뒤쪽에서 플레이어를 끌어당기는 탄막을 생성하여 장판에 가까워지도록 합니다.

- feat: 베이스, 스탯 시스템  도입
베이스에서는 체력, 플레이어 감지, 데미지 처리, 기본 상태를 관리합니다.
스탯 시스템에서는 최대 체력 물리 공격력 공격 속도 이동 속도 물리 방어력 마법 방어력을 관리합니다.

- feat: system의 follow boss, orb health, temp damage 최종보스를 구현할때 활용했던 스크립트입니다.

- fix: 에너미 스포너를 수정했습니다.
기본 코드는 구현하여 기본 몹은 나오는데 풀매니저 코드를 수정해서 ID를 이용하여 중간 보스와 최종 보스를 추가해야 하는데 아직 못 건드렸습니다.
<br/>

## 🔧 앞으로의 과제

- 미구현 이펙트, 렌더러 구현 및 임시 코드 삭제

- 탄환이나 광선 몹 특징 구현

- 에너미 스포너 완성

- HP UI 개선

- 코드 간결화 및 일관화

- 적 프리팹에서 타입 및 스탯 태그가 제대로 붙어 있는지 확인

  <br/>

## ➕ 이슈 링크

- [적 시스템 개발 #10] (https://github.com/DguFarmSystem/4th-game-lunebris/issues/10)

<br/>
